### PR TITLE
add bundle exec for docker setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you prefer to use Docker, you can quickly set things up using:
 docker-compose build
 docker-compose run web bundle install
 docker-compose run web yarn
-docker-compose run web rake db:create db:setup
+docker-compose run web bundle exec rake db:create db:setup
 ```
 
 And then to start services, just do `docker-compose up`.


### PR DESCRIPTION
otherwise you get this

Gem::LoadError: You have already activated rake 12.3.0, but your Gemfile requires rake 13.0.1. Prepending `bundle exec` to your command may solve this.