### PR TITLE
get grobid talking to webserver on docker image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,9 @@
-version: '3'
+version: "3"
 services:
   web:
     build: .
     command: ["./docker/web-startup.sh"]
-    volumes: 
+    volumes:
       - .:/app
     ports:
       - "3000:3000"
@@ -19,7 +19,7 @@ services:
       - RAILS_MAX_THREADS
       - PGHOST=db
       - PGUSER=postgres
-      - GROBID_HOST=http://localhost:8070/
+      - GROBID_URL=http://grobid:8070
     depends_on:
       - db
 
@@ -41,7 +41,11 @@ services:
 
   grobid:
     image: lfoppiano/grobid:0.5.6
-
+    ports:
+      - "8070:8070"
+      - "8071:8071"
+    expose:
+      - "8070"
 
 volumes:
   db-data:


### PR DESCRIPTION
Note: had to increase the Docker memory limit on my host machine to 4GB or the GROBID service would keep crashing. 
Note note: When it crashes, it doesn't restart; maybe there is a way to do that?