### PR TITLE
Cleanup citations parsing

### DIFF
--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -3,13 +3,13 @@
 # Table name: citations
 #
 #  id                :bigint           not null, primary key
-#  authors           :string
+#  authors           :text
 #  body              :json
 #  imprint_date      :string
 #  imprint_type      :string
 #  publisher         :string
 #  target            :string
-#  title             :string
+#  title             :text
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  generated_post_id :integer
@@ -22,6 +22,6 @@
 
 class Citation < ApplicationRecord
 	belongs_to :post
-	belongs_to :generated_post, class_name: 'Post', foreign_key: 'generated_post_id'
+	belongs_to :generated_post, class_name: 'Post', foreign_key: 'generated_post_id', dependent: :destroy
 
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,12 +3,12 @@
 # Table name: posts
 #
 #  id           :bigint           not null, primary key
-#  authors      :string
+#  authors      :text
 #  body         :json
 #  publish_date :datetime
 #  publisher    :string
 #  slug         :string
-#  title        :string
+#  title        :text
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
@@ -29,7 +29,7 @@ class Post < ApplicationRecord
 
 	accepts_nested_attributes_for :uploads
 
-  validates :title, length: { maximum: 120 }
+  validates :title, length: { maximum: 800 }
 
 	scope :primary, -> { joins(:uploads) }
 

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -3,12 +3,12 @@
 # Table name: posts
 #
 #  id           :bigint           not null, primary key
-#  authors      :string
+#  authors      :text
 #  body         :json
 #  publish_date :datetime
 #  publisher    :string
 #  slug         :string
-#  title        :string
+#  title        :text
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #

--- a/app/services/grobid_service.rb
+++ b/app/services/grobid_service.rb
@@ -10,7 +10,8 @@ class GrobidService
 	# Here are some sample grobid tasks from grobid service
 	GROBID_ENDPOINTS = {
 		full: "processFulltextDocument",
-		header: "processHeaderDocument"
+		header: "processHeaderDocument",
+		asset: "processFulltextAssetDocument"
 	}
 
 	def self.call(*args)
@@ -34,7 +35,15 @@ class GrobidService
 		# processHeaderDocument
 	end
 
-	private
+	# private
+
+		def processFulltextAssetDocument
+			endpoint = grobid_call(:asset)
+			resp = fire_away(endpoint)
+
+			body = resp["TEI"].to_xml
+			@upload_tei.update_attributes!(body: body)
+		end
 
 		def processFulltextDocument
 			endpoint = grobid_call(:full)
@@ -54,7 +63,16 @@ class GrobidService
 
 		def fire_away(endpoint)
 			resp = HTTParty.post(
-				endpoint, { body: { input: @file } }
+				endpoint, {
+					body: {
+						# teiCoordinates: "formula",
+						# teiCoordinates: "biblStruct",
+						# teiCoordinates: "ref",
+						teiCoordinates: "figure",
+						includeRawCitations: 1,
+						input: @file
+					}
+				}
 			)
 		end
 

--- a/app/views/uploads/show.html.slim
+++ b/app/views/uploads/show.html.slim
@@ -21,7 +21,8 @@
 			- @bib = @doc.css("biblStruct[@type='array']")
 
 			h3 Debug Bib
-			/ .markup
+			.markup
+				= @doc.to_xml
 				/ = @doc.css("biblStruct[@type='array']").children.to_xml.gsub("\n", "<br/>").gsub(" ", "-")
 
 			- @doc.css("biblStruct[@type='array']").children.css('biblStruct').each do |biblStruct|

--- a/db/migrate/20191210215019_change_string_columns_to_text_for_citations_and_posts.rb
+++ b/db/migrate/20191210215019_change_string_columns_to_text_for_citations_and_posts.rb
@@ -1,0 +1,9 @@
+class ChangeStringColumnsToTextForCitationsAndPosts < ActiveRecord::Migration[6.0]
+  def change
+    change_column :citations, :title, :text
+    change_column :citations, :authors, :text
+
+    change_column :posts, :title, :text
+    change_column :posts, :authors, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_07_031845) do
+ActiveRecord::Schema.define(version: 2019_12_10_215019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,8 +20,8 @@ ActiveRecord::Schema.define(version: 2019_12_07_031845) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "post_id"
     t.json "body"
-    t.string "title"
-    t.string "authors"
+    t.text "title"
+    t.text "authors"
     t.string "imprint_date"
     t.string "imprint_type"
     t.string "target"
@@ -31,13 +31,13 @@ ActiveRecord::Schema.define(version: 2019_12_07_031845) do
   end
 
   create_table "posts", force: :cascade do |t|
-    t.string "title"
+    t.text "title"
     t.json "body"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "slug"
     t.string "publisher"
-    t.string "authors"
+    t.text "authors"
     t.datetime "publish_date"
     t.index ["slug"], name: "index_posts_on_slug", unique: true
   end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -3,12 +3,12 @@
 # Table name: posts
 #
 #  id           :bigint           not null, primary key
-#  authors      :string
+#  authors      :text
 #  body         :json
 #  publish_date :datetime
 #  publisher    :string
 #  slug         :string
-#  title        :string
+#  title        :text
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -3,12 +3,12 @@
 # Table name: posts
 #
 #  id           :bigint           not null, primary key
-#  authors      :string
+#  authors      :text
 #  body         :json
 #  publish_date :datetime
 #  publisher    :string
 #  slug         :string
-#  title        :string
+#  title        :text
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -3,12 +3,12 @@
 # Table name: posts
 #
 #  id           :bigint           not null, primary key
-#  authors      :string
+#  authors      :text
 #  body         :json
 #  publish_date :datetime
 #  publisher    :string
 #  slug         :string
-#  title        :string
+#  title        :text
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -3,12 +3,12 @@
 # Table name: posts
 #
 #  id           :bigint           not null, primary key
-#  authors      :string
+#  authors      :text
 #  body         :json
 #  publish_date :datetime
 #  publisher    :string
 #  slug         :string
-#  title        :string
+#  title        :text
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #


### PR DESCRIPTION
Fixed an edge case where titles were long, this turns those columns into text columns instead of strings.