### PR TITLE
dockerize dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,36 +12,78 @@ Shrine and Google Cloud Engine are used for file storage.
 
 This app is pre-alpha, so please mind the cracks.
 
+## Development
 
-### Development
+### Local Development
 
-To get this app up and running, follow the [instructions for getting started](https://github.com/jellypbc/poster/wiki/Setup).
+To get this app up and running locally, follow these steps:
 
+- Follow the [setup guide in the wiki](https://github.com/jellypbc/poster/wiki/Setup) to install `rbenv`, `bundler`, and `yarn`
+- Install `docker` and `docker-compose` from Brew or through [Docker Desktop](https://www.docker.com/products/docker-desktop)
+  - Make sure to give Docker several GB of memory for the Grobid server
+
+#### Startup
+
+```sh
+# 1. Install packages
+bundle install
+# 2. Set up database
+bundle exec rails rails db:schema:load
+```
+
+```sh
+# Start server on default port localhost:3000
+bundle exec rails server
+```
+
+#### Teardown
+
+To rebuild the docker environment (for example after changing the service configuration):
+
+```sh
+# Stop services
+docker-compose down
+# Pull to rerun init scripts
+docker-compose pull
+# Then follow startup steps again
+```
+
+#### Creating Users
+
+- Start the services
+- Go to http://localhost:3000/users/sign_up
+- Create an account
+- Look at Rails logs for confirmation email html
+- Click confirmaton link
+- Sign in
 
 ### Deploying
 
 This app depends on Grobid running as a separate service, which you'll want to set a production env variable `GROBID_URL`.
 
 To do so, you'll want to pull the docker image and start it on port 80.
+
 ```
+
 docker pull lfoppiano/grobid:{version}
 docker run -t --rm --init -p 80:8070 -p 8080:8080 lfoppiano/grobid:{version}
+
 ```
 
-
-### Development
+### Wiki
 
 Check out the [wiki](https://github.com/jellypbc/poster/wiki) and issues to see the current status.
-
 
 ### Running GCE commands
 
 Running Migrations on GCE
+
 ```shell
 bundle exec rake appengine:exec -- bundle exec rake db:create
 ```
 
 ## Roadmap / Product Horizons
+
 Here are some of the things we will playing around with in this toy app, kind of like a list of to-do's.
 
 - multiplayer RT-crdt based syncing

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,6 +6,9 @@ default: &default
 development:
   <<: *default
   database: jellyposter_development
+  host: localhost
+  port: 5432
+  user: jelly
 
 test:
   <<: *default
@@ -18,4 +21,4 @@ production:
   username: "postgres"
   password: "postgres"
   database: "jellyposter-prod"
-  host:   "/cloudsql/jellyposter:us-west1:jellyposter-prod-pg"
+  host: "/cloudsql/jellyposter:us-west1:jellyposter-prod-pg"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,9 +3,25 @@ version: "3"
 services:
   grobid:
     image: lfoppiano/grobid:0.5.6
+    restart: on-failure
     ports:
       - "8070:8070"
       - "8071:8071"
     expose:
       - "8070"
-
+  postgres:
+    image: postgres:12
+    restart: always
+    environment:
+      - POSTGRES_USER=jelly
+    ports:
+      - "5432:5432"
+    expose:
+      - "5432"
+  redis:
+    image: redis:5.0.7
+    restart: always
+    ports:
+      - "6379:6379"
+    expose:
+      - "6379"


### PR DESCRIPTION
- Run these services in Docker:
  - grobid
  - postgres
  - redis
- Add docs (note: follow teardown instructions
  in readme for existing docker setups so that
  the postgres user gets set up properly)
- The services forward ports so they should
  act the same as local versions from the Rails server's point of view