### PR TITLE
Fixes actioncable

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -40,7 +40,7 @@ class PostSerializer
   end
 
   attribute :cable_url do |object|
-    Rails.env.development? ? "ws://localhost:3000/cable" : "#{ENV["REDIS_URL"]}"
+    Rails.env.development? ? "ws://localhost:3000/cable" : "ws://#{ENV["HOSTNAME"]}/cable"
   end
 
   attribute :upload_url do |object|

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -2,4 +2,5 @@ const { environment } = require('@rails/webpacker')
 const typescript =  require('./loaders/typescript')
 
 environment.loaders.prepend('typescript', typescript)
+environment.loaders.delete('nodeModules')
 module.exports = environment


### PR DESCRIPTION
For some reason, @rails/actioncable breaks when importing in production (see https://github.com/rails/rails/issues/35501, and https://github.com/rails/webpacker/blob/master/docs/v4-upgrade.md#excluding-node_modules-from-being-transpiled-by-babel-loader), this should fix it.