### PR TITLE
set post to belong to unique user on post creation

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,6 +22,10 @@ class PostsController < ApplicationController
   def create
     @post = Post.new(post_params)
 
+    if signed_in?
+      @post.user_id = current_user.id
+    end
+
     respond_to do |format|
       if @post.save
         format.html { redirect_to @post, notice: 'Post was successfully created.' }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -40,7 +40,7 @@ class Post < ApplicationRecord
 
 	scope :primary, -> { joins(:uploads) }
 
-  belongs_to :user
+  belongs_to :user, optional: true
 
 	def to_param
     slug

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -40,6 +40,8 @@ class Post < ApplicationRecord
 
 	scope :primary, -> { joins(:uploads) }
 
+  belongs_to :user
+
 	def to_param
     slug
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :confirmable, :lockable, :timeoutable
 
+  has_many :posts
+
 	def send_devise_notification(notification, *args)
 		devise_mailer.send(notification, self, *args).deliver_later
 	end


### PR DESCRIPTION
- [x] sets ```post.user_id``` to ```current_user.id``` if ```signed_in?```
- [x] creates active record associations between users and posts
- [ ] test that this works for posts created by pdf upload

next for posts:
- [ ] add ```deleted_at``` ```published_at``` ```unpublished_at``` ```private``` columns to ```posts```
- [ ] default posts to ```private = true```
- [ ] add publish functionality to set ```published_at```
- [ ] add delete functionality to set ```deleted_at```