### PR TITLE
only show posts that are pdf uploads in index

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,7 @@ class PostsController < ApplicationController
   before_action :set_post, only: [:show, :edit, :update, :destroy]
 
   def index
-    @posts = Post.all
+    @posts = Post.primary
       .order(created_at: :desc)
       .paginate(page: params[:page], per_page: 40)
   end


### PR DESCRIPTION
i made a change last week that shows all posts

when i am demoing, it is difficult for me to locate the post that was the upload

so changing it back to ```Post.primary```