### PR TITLE
fixes infinite loop of PostProcessingPlaceholder on references and new posts

### DIFF
--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -49,7 +49,7 @@ class PostEditor extends React.Component {
       errorAt: null, // string or null
       lastSavedAt: getTimestamp('updated_at', props.post), // string or null
       lastUnsavedChangeAt: null, // Date object or null, used to track dirty state
-      isProcessing: !this.props.post.data.attributes.title || false, // TODO: move this into container
+      isProcessing: this.props.isProcessing || false, // TODO: move this into container
       isEditable: true,
     }
 

--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -49,7 +49,7 @@ class PostEditor extends React.Component {
       errorAt: null, // string or null
       lastSavedAt: getTimestamp('updated_at', props.post), // string or null
       lastUnsavedChangeAt: null, // Date object or null, used to track dirty state
-      isProcessing: !this.props.post.data.attributes.body || false, // TODO: move this into container
+      isProcessing: !this.props.post.data.attributes.title || false, // TODO: move this into container
       isEditable: true,
     }
 

--- a/app/javascript/components/PostViewer.js
+++ b/app/javascript/components/PostViewer.js
@@ -49,7 +49,7 @@ class PostViewer extends React.Component {
       errorAt: null, // string or null
       lastSavedAt: getTimestamp('updated_at', props.post), // string or null
       lastUnsavedChangeAt: null, // Date object or null, used to track dirty state
-      isProcessing: !this.props.post.data.attributes.body || false, // TODO: move this into container
+      isProcessing: this.props.isProcessing || false, // TODO: move this into container
       isEditable: false,
     }
 

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -7,7 +7,7 @@
 
     .editor
       - if current_user && (@post.user && @post.user == current_user)
-        = react_component "PostPage", { post: PostSerializer.new(@post).serializable_hash, currentUser: current_user.present? ? UserSerializer.new(current_user) : nil }
+        = react_component "PostPage", { post: PostSerializer.new(@post).serializable_hash, currentUser: current_user.present? ? UserSerializer.new(current_user) : nil, isProcessing: @post.body.nil? }
       - else
         = react_component "PostViewer", { post: PostSerializer.new(@post).serializable_hash, currentUser: current_user.present? ? UserSerializer.new(current_user) : nil }
 


### PR DESCRIPTION
setting ```isProcessing``` to true based on the presence of the post body causes posts that are autogenerated reference posts and standalone posts created to display PostProcessPlaceholder (flubber animation) on infinite loop

this fix explicitly sets ```isProcessing``` state for posts with PDF upload

before: 
![Kapture 2020-03-28 at 15 59 26](https://user-images.githubusercontent.com/1177031/77838177-2e171680-710d-11ea-8f85-24961c9a3464.gif)

after:
![Kapture 2020-03-28 at 16 00 45](https://user-images.githubusercontent.com/1177031/77838193-51da5c80-710d-11ea-9040-4ff40c41c675.gif)




