### PR TITLE
Fixes /dashboard visual UI

### DIFF
--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -82,16 +82,18 @@
 
 #dashboard {
   h4 {
-    font-weight: 500;
-    font-family: 'New York';
-    text-transform: capitalize;
-    font-variant: small-caps;
+    font-family: $baseFontFamily;
     font-weight: bold;
-    letter-spacing: 0.2px;
+    // font-weight: 500;
+    // text-transform: capitalize;
+    // font-variant: small-caps;
+    // font-family: 'New York';
+    // letter-spacing: 0.2px;
+
   }
   h2 {
-    font-family: 'Times New Roman';
-    // font-family: $serifFontFamily;
+    font-family: $baseFontFamily;
+    // font-family: 'Times New Roman';
   }
 }
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,10 +9,9 @@ class PagesController < ApplicationController
       @no_nav = true
 
     else
-      @posts = Post.primary
-      .includes(:tags, :uploads, :user)
-      .last(3)
-      .reverse
+      @posts = current_user.posts.primary
+      .includes(:tags)
+      .order(created_at: :desc)
       @tags = @posts.map(&:tags).flatten
       render 'dashboard'
     end

--- a/app/views/pages/dashboard.html.slim
+++ b/app/views/pages/dashboard.html.slim
@@ -21,27 +21,22 @@
         - @posts.each do |post|
           - resource = post.user_id? ? short_user_post_path(post.user, post) : post_path(post)
 
+
           = link_to resource do
-            h4.title.my-2
+          .post
+            h4.title
               = sanitize_title(post.title) || "Title"
-            p.authors
-              = sanitize_title(post.authors)
 
-          / = link_to resource do
-          / .post
-          /   h4.title
-          /     = sanitize_title(post.title) || "Title"
+            .preview
+              - if post.abstract
+                = post.abstract.truncate(200, seperator: "...")
+            div
+              span.date.mr-4
+                = post.created_at.strftime("%b %d, %Y")
+              span.link
+                = link_to post do
+                  | ⌞ View article
 
-          /   .preview
-          /     - if post.abstract
-          /       = post.abstract.truncate(200, seperator: "...")
-          /   div
-          /     span.date.mr-4
-          /       = post.created_at.strftime("%b %d, %Y")
-          /     span.link
-          /       = link_to post do
-          /         | ⌞ View article
-
-          /     - options = {}; options[:include] = [:uploads]
-          /     = react_component 'TagForm', taggable: PostSerializer.new(post, options)
+              - options = {}; options[:include] = [:uploads]
+              = react_component 'TagForm', taggable: PostSerializer.new(post, options)
 


### PR DESCRIPTION
fixes https://github.com/jellypbc/poster/issues/144

- [x] updates root and /dashboard to show the same content

the problem is root and /dashboard looks broken to the user. i commented out some css to make the visual UI look usable. i understand that @dennyluan is working on final scaffolding this week.

the reason this needs to be addressed before @dennyluan is finished with dashboard scaffolding is right now when users go to root or /dashboard while logged in is the page looks unfinished

before:
![image](https://user-images.githubusercontent.com/1177031/78948443-0bb5bf00-7a64-11ea-8f52-972df117ac31.png)

after: 
![image](https://user-images.githubusercontent.com/1177031/78948419-f5a7fe80-7a63-11ea-8f69-a981147a7e0a.png)
