### PR TITLE
Fixes comment deco position bug

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -51,10 +51,7 @@ class PostsController < ApplicationController
     # binding.pry
     respond_to do |format|
       if @post.update!(post_params)
-
-        if params[:comments]
-
-        end
+        update_comments(@post) if params[:comments]
         format.html { redirect_to @post, notice: 'Post was successfully updated.' }
         format.json { render json: { post: PostSerializer.new(@post).as_json } }
       else
@@ -140,6 +137,23 @@ class PostsController < ApplicationController
           color: tag.color,
         }}
         .as_json
+    end
+
+    def update_comments(post)
+      if comments_data = JSON.parse(params['comments'])
+        comments_data.each do |comment_data|
+          comment = Comment.find_or_create_by(
+            data_key: comment_data["id"].to_s,
+            post_id: post.id
+          )
+
+          comment.update(
+            text: comment_data["text"],
+            data_from: comment_data["from"],
+            data_to: comment_data["to"]
+          )
+        end
       end
+    end
 
 end

--- a/app/javascript/components/Editor.js
+++ b/app/javascript/components/Editor.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { EditorState } from 'prosemirror-state'
 import { EditorView } from 'prosemirror-view'
 import { pluginKey as commentPluginKey } from './editor-config/plugin-comment'
-import applyDevTools from 'prosemirror-dev-tools'
+// import applyDevTools from 'prosemirror-dev-tools'
 
 class Editor extends React.Component {
   constructor(props) {
@@ -43,7 +43,7 @@ class Editor extends React.Component {
       }.bind(this),
     })
 
-    applyDevTools(this.view)
+    // applyDevTools(this.view)
   }
 
   componentDidMount() {

--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -182,38 +182,21 @@ class PostEditor extends React.Component {
   )
 
   updatePost = (doc, docState) => {
+    var { post } = this.state
     // do not read from this.state after setState, it will not update until rerender
     this.setState({ isLoading: true })
-    var { post } = this.state
     const isNewPost = getIsNewPost(post)
 
-    const commentState = commentPluginKey.getState(docState)
-
-    const newCommentsToSave = commentState.unsent
-      .filter((action) => action.type === 'newComment')
-      .map(serializeComment)
-
-    // TODO: serialize JSON on server instead of parsing string?
-    const oldPluginState = post.data.attributes.comments
-
-    const comments = [...(oldPluginState || []), ...newCommentsToSave].filter(
-      (comment) => {
-        return !commentState.unsent.find((action) => {
-          const isDeletable = action.type === 'deleteComment'
-          const isTheComment = action.comment.id === comment.id
-          return isDeletable && isTheComment
-        })
-      }
+    const comments = JSON.stringify(
+      commentPluginKey.getState(docState).allComments()
     )
-    let decos = commentState.decos.map((c) => c)
-
-    var url = isNewPost ? '/posts' : post.data.attributes.form_url
-    var data = {
+    const url = isNewPost ? '/posts' : post.data.attributes.form_url
+    const data = {
       body: doc,
       comments: comments,
     }
-    var method = isNewPost ? 'post' : 'put'
-    var token = document.head.querySelector('[name~=csrf-token][content]')
+    const method = isNewPost ? 'post' : 'put'
+    const token = document.head.querySelector('[name~=csrf-token][content]')
       .content
 
     superagent[method](url)

--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -14,10 +14,7 @@ import ChangesIndicator from './ChangesIndicator'
 import PostProcessingPlaceholder from './PostProcessingPlaceholder'
 import { options, menu, annotationMenu } from './editor-config/index'
 
-import {
-  pluginKey as commentPluginKey,
-  serialize as serializeComment,
-} from './editor-config/plugin-comment'
+import { pluginKey as commentPluginKey } from './editor-config/plugin-comment'
 
 import {
   getTimestamp,

--- a/app/javascript/components/editor-config/plugin-comment.js
+++ b/app/javascript/components/editor-config/plugin-comment.js
@@ -39,6 +39,19 @@ class CommentState {
     return this.decos.find(pos, pos)
   }
 
+  allComments() {
+    let { decos } = this
+    const comments = decos.find().map((comment) => {
+      return {
+        to: comment.to,
+        from: comment.from,
+        id: comment.type.spec.comment.id,
+        text: comment.type.spec.comment.text,
+      }
+    })
+    return comments
+  }
+
   apply(tr) {
     let action = tr.getMeta(commentPlugin),
       actionType = action && action.type
@@ -67,6 +80,7 @@ class CommentState {
     let decos = existingComments.map((c) =>
       deco(c.from, c.to, new Comment(c.text, c.id))
     )
+
     return new CommentState(
       config.comments.version,
       DecorationSet.create(config.doc, decos),


### PR DESCRIPTION
This is kind of not ideal, but it fixes the comments losing their position by updating each comment on `updatePost()` from pulling from the DecorationSet in the editor's comment plugin.

Also fixes https://github.com/jellypbc/poster/issues/171