### PR TITLE
Fix placeholder removal for searchbar and posteditor

### DIFF
--- a/app/javascript/components/Floater.js
+++ b/app/javascript/components/Floater.js
@@ -20,7 +20,7 @@ class Floater extends React.Component {
     })
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.setState({
       style: this.calculateStyle(nextProps),
     })

--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -91,10 +91,9 @@ class PostEditor extends React.Component {
     this.removeStaticRenderPlaceholder()
   }
 
-  // Remove the static placeholder content once component renders
   removeStaticRenderPlaceholder = () => {
     var placeholder = document.getElementsByClassName('placeholder-content')[0]
-    placeholder.remove()
+    if (placeholder) placeholder.remove()
   }
 
   handleTitleChange = (doc, docState) => {

--- a/app/javascript/components/SearchBar.js
+++ b/app/javascript/components/SearchBar.js
@@ -13,9 +13,8 @@ class SearchBar extends React.Component {
   }
 
   componentDidMount() {
-    // remove the fallback searchbar
     var placeholder = document.getElementById('search-fallback')[0]
-    placeholder.remove()
+    if (placeholder) placeholder.remove()
 
     var searchbar = document.getElementsByClassName('search-bar')[0]
     searchbar.addEventListener('keyup', (event) => {


### PR DESCRIPTION
When navigating back to a page, the components that had placeholders were looking for elements that were removed and breaking the rest of the page.

Fixes https://github.com/jellypbc/poster/issues/167