### PR TITLE
Add field_type to comments and add commenting by editor field

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -73,7 +73,7 @@ class CommentsController < ApplicationController
     def comment_params
       params.require(:comment).permit(
         :text, :data_to, :data_from, :data_key,
-        :user_id, :post_id, :deleted_at
+        :user_id, :post_id, :deleted_at, :field_type
       )
     end
 

--- a/app/javascript/components/Editor.js
+++ b/app/javascript/components/Editor.js
@@ -7,7 +7,8 @@ import { pluginKey as commentPluginKey } from './editor-config/plugin-comment'
 class Editor extends React.Component {
   constructor(props) {
     super(props)
-    console.log(props.field.toUpperCase() + ' EDITOR PROPS', props)
+    const { field } = props
+    console.log(field.toUpperCase() + ' EDITOR PROPS', props)
 
     this.editorRef = React.createRef()
 
@@ -17,6 +18,7 @@ class Editor extends React.Component {
       // prosemirror options = { plugins, schema, comments: { comments: [] } }
       state: EditorState.create({
         ...props.options,
+        field: props.field,
         plugins: props.options.setupPlugins(getView),
       }),
       dispatchTransaction: (transaction) => {

--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -224,11 +224,14 @@ class PostEditor extends React.Component {
     const hasUnsavedChanges = lastSavedAtDate < lastUnsavedChangeAt
 
     options.doc = this.parse(body) // TODO: don't mutate "options"
-    options.doc.comments = { comments: post.data.attributes.comments }
+    options.doc.comments = { comments: post.data.attributes.body_comments }
 
     var titleOptions = Object.assign({}, options)
     titleOptions.doc = this.parse(title)
-    titleOptions.doc.commets = { comments: post.data.attributes.comments }
+    titleOptions.doc.comments = {
+      comments: post.data.attributes.title_comments,
+    }
+    // titleOptions.comments = { comments: post.data.attributes.comments }
 
     return (
       <div>

--- a/app/javascript/components/editor-config/plugin-comment.js
+++ b/app/javascript/components/editor-config/plugin-comment.js
@@ -24,10 +24,11 @@ function deco(from, to, comment) {
 }
 
 class CommentState {
-  constructor(version, decos, unsent) {
+  constructor(version, decos, unsent, field) {
     this.version = version
     this.decos = decos
     this.unsent = unsent
+    this.field = field
   }
 
   findComment(id) {
@@ -58,19 +59,19 @@ class CommentState {
       actionType = action && action.type
     if (!action && !tr.docChanged) return this
     let base = this
-    let { decos, unsent } = base
+    let { decos, unsent, field } = base
     decos = decos.map(tr.mapping, tr.doc)
 
     if (actionType == 'newComment') {
       decos = decos.add(tr.doc, [deco(action.from, action.to, action.comment)])
       unsent = unsent.concat(action)
-      submitCreateComment(action, action.comment)
+      submitCreateComment(action, action.comment, field)
     } else if (actionType == 'deleteComment') {
       decos = decos.remove([this.findComment(action.comment.id)])
       unsent = unsent.concat(action)
       submitDeleteComment(action.comment)
     }
-    return new CommentState(base.version, decos, unsent)
+    return new CommentState(base.version, decos, unsent, field)
   }
 
   static init(config) {
@@ -86,7 +87,8 @@ class CommentState {
     return new CommentState(
       config.comments.version,
       DecorationSet.create(config.doc, decos),
-      []
+      [],
+      config.field
     )
   }
 }
@@ -130,15 +132,16 @@ function submitDeleteComment(comment) {
   submitRequest(data, url)
 }
 
-function submitCreateComment(sel, comment) {
+function submitCreateComment(action, comment, field) {
   var url = '/add_comment'
   var { currentUser, currentPost } = store.getState()
   var data = {
     comment: {
-      data_to: sel.to,
-      data_from: sel.from,
+      data_to: action.to,
+      data_from: action.from,
       data_key: comment.id,
       text: comment.text,
+      field_type: field,
     },
   }
   if (currentPost) {

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -8,6 +8,7 @@
 #  data_key         :string
 #  data_to          :string
 #  deleted_at       :datetime
+#  field_type       :integer
 #  hidden           :boolean
 #  highlighted_text :text
 #  text             :text
@@ -18,10 +19,11 @@
 #
 # Indexes
 #
-#  index_comments_on_ancestry  (ancestry)
-#  index_comments_on_data_key  (data_key) UNIQUE
-#  index_comments_on_post_id   (post_id)
-#  index_comments_on_user_id   (user_id)
+#  index_comments_on_ancestry    (ancestry)
+#  index_comments_on_data_key    (data_key) UNIQUE
+#  index_comments_on_field_type  (field_type)
+#  index_comments_on_post_id     (post_id)
+#  index_comments_on_user_id     (user_id)
 #
 
 class Comment < ApplicationRecord
@@ -29,6 +31,8 @@ class Comment < ApplicationRecord
 
   belongs_to :post
   belongs_to :user, optional: true
+
+  enum field_type: { body: 0, title: 1 }
 
   default_scope { where(deleted_at: nil) }
 

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -8,6 +8,7 @@
 #  data_key         :string
 #  data_to          :string
 #  deleted_at       :datetime
+#  field_type       :integer
 #  hidden           :boolean
 #  highlighted_text :text
 #  text             :text
@@ -18,10 +19,11 @@
 #
 # Indexes
 #
-#  index_comments_on_ancestry  (ancestry)
-#  index_comments_on_data_key  (data_key) UNIQUE
-#  index_comments_on_post_id   (post_id)
-#  index_comments_on_user_id   (user_id)
+#  index_comments_on_ancestry    (ancestry)
+#  index_comments_on_data_key    (data_key) UNIQUE
+#  index_comments_on_field_type  (field_type)
+#  index_comments_on_post_id     (post_id)
+#  index_comments_on_user_id     (user_id)
 #
 
 class CommentSerializer

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -67,8 +67,35 @@ class PostSerializer
     }.as_json
   end
 
-  attribute :comments do |object|
-    object.comments.map{ |comment|
+  attribute :title_comments do |object|
+    object.comments.title.map{ |comment|
+
+      if comment.user
+        user = {
+          id: comment.user.id,
+          avatar: comment.user.avatar_url,
+          name: comment.user.full_name,
+        }
+      else
+        user = {
+          id: "",
+          avatar: User.default_avatar_url,
+          name: "Anonymous",
+        }
+      end
+
+      {
+        to: comment.data_to.to_i,
+        from: comment.data_from.to_i,
+        id: comment.data_key.to_i,
+        text: comment.text,
+        user: user,
+      }
+    }.as_json
+  end
+
+  attribute :body_comments do |object|
+    object.comments.body.map{ |comment|
 
       if comment.user
         user = {

--- a/db/migrate/20200502020343_add_field_type_to_comments.rb
+++ b/db/migrate/20200502020343_add_field_type_to_comments.rb
@@ -1,0 +1,5 @@
+class AddFieldTypeToComments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comments, :field_type, :integer
+  end
+end

--- a/db/migrate/20200502024810_add_index_to_comment_field_type.rb
+++ b/db/migrate/20200502024810_add_index_to_comment_field_type.rb
@@ -1,0 +1,5 @@
+class AddIndexToCommentFieldType < ActiveRecord::Migration[6.0]
+  def change
+    add_index :comments, :field_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_24_025314) do
+ActiveRecord::Schema.define(version: 2020_05_02_024810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,8 +43,10 @@ ActiveRecord::Schema.define(version: 2020_04_24_025314) do
     t.string "data_from"
     t.string "data_key"
     t.datetime "deleted_at"
+    t.integer "field_type"
     t.index ["ancestry"], name: "index_comments_on_ancestry"
     t.index ["data_key"], name: "index_comments_on_data_key", unique: true
+    t.index ["field_type"], name: "index_comments_on_field_type"
     t.index ["post_id"], name: "index_comments_on_post_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -8,6 +8,7 @@
 #  data_key         :string
 #  data_to          :string
 #  deleted_at       :datetime
+#  field_type       :integer
 #  hidden           :boolean
 #  highlighted_text :text
 #  text             :text
@@ -18,10 +19,11 @@
 #
 # Indexes
 #
-#  index_comments_on_ancestry  (ancestry)
-#  index_comments_on_data_key  (data_key) UNIQUE
-#  index_comments_on_post_id   (post_id)
-#  index_comments_on_user_id   (user_id)
+#  index_comments_on_ancestry    (ancestry)
+#  index_comments_on_data_key    (data_key) UNIQUE
+#  index_comments_on_field_type  (field_type)
+#  index_comments_on_post_id     (post_id)
+#  index_comments_on_user_id     (user_id)
 #
 
 FactoryBot.define do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -8,6 +8,7 @@
 #  data_key         :string
 #  data_to          :string
 #  deleted_at       :datetime
+#  field_type       :integer
 #  hidden           :boolean
 #  highlighted_text :text
 #  text             :text
@@ -18,10 +19,11 @@
 #
 # Indexes
 #
-#  index_comments_on_ancestry  (ancestry)
-#  index_comments_on_data_key  (data_key) UNIQUE
-#  index_comments_on_post_id   (post_id)
-#  index_comments_on_user_id   (user_id)
+#  index_comments_on_ancestry    (ancestry)
+#  index_comments_on_data_key    (data_key) UNIQUE
+#  index_comments_on_field_type  (field_type)
+#  index_comments_on_post_id     (post_id)
+#  index_comments_on_user_id     (user_id)
 #
 
 require 'rails_helper'


### PR DESCRIPTION
This PR breaks comments out into different `field_type`'s based on the editor (e.g. title editor, body editor), and integrates it into the Comment Plugin to support different types of comments.

Post-merge: Because this is a new column, all existing comments will no longer show up. For now, we'll migrate all existing comments to be body comments. 

![image](https://user-images.githubusercontent.com/929010/80853448-b84f1080-8bcc-11ea-933b-4d9cf2d13e0c.png)
