### PR TITLE
Fixes registration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,7 +89,7 @@ class User < ApplicationRecord
   private
 
     def set_username
-      self.username = self.email[/^[^@]+/]
+      self.username = self.email[/^[^@]+/].tr('.','') if username.blank?
     end
 
 end


### PR DESCRIPTION
fixes https://github.com/jellypbc/poster/issues/189 https://github.com/jellypbc/poster/issues/188

- [x] only run ```set_username``` if ```username``` is blank
- [x] updates ```set_username``` to strip all `.` from usernames

know issue:
- users can intentionally set username with a ```.``` which will return an error on /write /settings