### PR TITLE
Updates diborg to return a single copy of parsed text

### DIFF
--- a/app/services/diborg_service.rb
+++ b/app/services/diborg_service.rb
@@ -161,8 +161,8 @@ class DiborgService
 		end
 
 		def parse_body
-      replace_refs
-			@doc.css('body div').to_xml
+      replace_refs_to_remove_inline_citations
+			@doc.css('body').to_xml
 		end
 
 		def parse_citation(bibStruct)
@@ -203,7 +203,7 @@ class DiborgService
 			return title
 		end
 
-    def replace_refs
+    def replace_refs_to_remove_inline_citations
       @doc.css('ref').map {|r| r.remove }
     end
 end


### PR DESCRIPTION
fixes #134 

We tested this branch using this PDF and the app will not return duplicate text. https://arxiv.org/pdf/1703.01192.pdf