### PR TITLE
Added ID to tags table JEL-91

### DIFF
--- a/app/views/tags/index.html.slim
+++ b/app/views/tags/index.html.slim
@@ -9,6 +9,7 @@
       table.table
         thead
           tr
+            th ID
             th Text
             th Slug
             th colspan="3"
@@ -16,6 +17,7 @@
         tbody
           - @tags.each do |tag|
             tr
+              td = tag.id
               td = tag.text
               td = tag.slug
               td = link_to 'Show', tag


### PR DESCRIPTION
This modifies the tags table (poster.jellypbc.com/tags) to include the ID of the tag. Created by Cindy and I during a pair programming session. Go team! 

Before:
![image](https://user-images.githubusercontent.com/41090933/83576302-6d902380-a4ff-11ea-88c4-ae0c288606e3.png)

After:
![image](https://user-images.githubusercontent.com/41090933/83576325-7bde3f80-a4ff-11ea-8c41-01f1fe6a0605.png)
