### PR TITLE
Fixes 500 error on /users JEL-111

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -50,4 +50,8 @@ module UsersHelper
     "<div class='#{klasses}' style='#{style}'></div>".html_safe
   end
 
+  def time_since_last_comment(user)
+    time_ago_in_words(user.comments.last.updated_at) + " ago" unless user.comments.last.blank?
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,8 +92,7 @@ class User < ApplicationRecord
       )
     end
   end
-  def last_commented
-    #last_commented = comments.last ? comments.last.updated_at : "none"
+  def time_since_last_comment
     last_commented = time_ago_in_words(comments.last.updated_at) unless comments.last.blank?
   end
   private
@@ -101,6 +100,5 @@ class User < ApplicationRecord
     def set_username
       username = email[/^[^@]+/].tr('.','') if username.blank?
     end
-
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@
 #  username               :string           default(""), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-# 
+#
 # Indexes
 #
 #  index_users_on_confirmation_token    (confirmation_token) UNIQUE
@@ -31,7 +31,7 @@
 #  index_users_on_unlock_token          (unlock_token) UNIQUE
 #  index_users_on_username              (username) UNIQUE
 #
-include ActionView::Helpers::DateHelper
+
 
 class User < ApplicationRecord
   include AvatarUploader::Attachment(:avatar)
@@ -92,9 +92,7 @@ class User < ApplicationRecord
       )
     end
   end
-  def time_since_last_comment
-    last_commented = time_ago_in_words(comments.last.updated_at) unless comments.last.blank?
-  end
+
   private
 
     def set_username

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@
 #  username               :string           default(""), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#
+# 
 # Indexes
 #
 #  index_users_on_confirmation_token    (confirmation_token) UNIQUE
@@ -31,6 +31,7 @@
 #  index_users_on_unlock_token          (unlock_token) UNIQUE
 #  index_users_on_username              (username) UNIQUE
 #
+include ActionView::Helpers::DateHelper
 
 class User < ApplicationRecord
   include AvatarUploader::Attachment(:avatar)
@@ -91,11 +92,15 @@ class User < ApplicationRecord
       )
     end
   end
-
+  def last_commented
+    #last_commented = comments.last ? comments.last.updated_at : "none"
+    last_commented = time_ago_in_words(comments.last.updated_at) unless comments.last.blank?
+  end
   private
 
     def set_username
       username = email[/^[^@]+/].tr('.','') if username.blank?
     end
+
 
 end

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -2,7 +2,7 @@
   .row
     .col-md-12
       h1 Users
-      br 
+      br
       table.table
         thead
           tr
@@ -22,7 +22,7 @@
               td = user.email
               td = user.posts.count
               td = user.comments.count
-              td = user.time_since_last_comment
+              td = time_since_last_comment(user)
               td = link_to 'Show', user
               td = link_to 'Edit', edit_user_path(user)
               td = link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' }

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -22,7 +22,7 @@
               td = user.email
               td = user.posts.count
               td = user.comments.count
-              td = time_ago_in_words(user.comments.last.updated_at) + " ago"
+              td = user.last_commented
               td = link_to 'Show', user
               td = link_to 'Edit', edit_user_path(user)
               td = link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' }

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -22,7 +22,7 @@
               td = user.email
               td = user.posts.count
               td = user.comments.count
-              td = user.last_commented
+              td = user.time_since_last_comment
               td = link_to 'Show', user
               td = link_to 'Edit', edit_user_path(user)
               td = link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' }


### PR DESCRIPTION
Fixes 500 error with /users that occurs when `user.comments` returns `nil`. ~~Updates user model to include the time since the user's last comment.~~

Moves logic from the view into users helper. 

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/41090933/84227104-8a08fe80-aab1-11ea-90ed-fb7fae68a1b9.png">
