### PR TITLE
Fixes "null" page title bug when title editor is empty JEL-114

### DIFF
--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -123,7 +123,9 @@ class PostEditor extends React.Component {
     })
 
     if (window.history.replaceState) {
-      document.title = title
+      // Accounts for when there is no title for document
+      document.title = title == null ? title : 'Untitled | Jelly Poster'
+
       window.history.replaceState(
         {},
         title,


### PR DESCRIPTION
Fixes a bug where if the title of a post is empty, the title of the page returns null. Replaces all cases of this occurrence with "Untitled".
Before:
![image](https://user-images.githubusercontent.com/41090933/84606464-6dcfdd80-ae74-11ea-9853-366705a3470a.png)
After:
![image](https://user-images.githubusercontent.com/41090933/84606458-627cb200-ae74-11ea-9405-7bbf8d786be5.png)