### PR TITLE
Separate editor menu bar into two menu bars JEL-128

### DIFF
--- a/app/assets/stylesheets/editor/menubar.css
+++ b/app/assets/stylesheets/editor/menubar.css
@@ -22,7 +22,7 @@
 .button {
 	background: #fff;
 	border: none;
-	font-size: inherit;
+	font-size: 80%;
 	cursor: pointer;
 	color: #777;
 	border-radius: 0;

--- a/app/javascript/components/MenuBar.js
+++ b/app/javascript/components/MenuBar.js
@@ -25,7 +25,7 @@ const Button = ({ state, dispatch }) => (item, key) => (
 
 const MenuBar = ({ menu, children, view }) => (
   <div>
-    <div className="bar">
+    <div className="bar vertical">
       {children && <span className="group">{children}</span>}
 
       {map(menu, (item, key) => (

--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -9,6 +9,7 @@ import { store } from './store'
 import Editor from './Editor'
 import Floater from './Floater'
 import MenuBar from './MenuBar'
+import VertMenuBar from './VerticalMenuBar'
 import PostMasthead from './PostMasthead'
 import ChangesIndicator from './ChangesIndicator'
 import PostProcessingPlaceholder from './PostProcessingPlaceholder'
@@ -16,6 +17,7 @@ import {
   options,
   titleOptions,
   menu,
+  menu2,
   titleMenu,
   annotationMenu,
 } from './editor-config/index'
@@ -205,11 +207,11 @@ class PostEditor extends React.Component {
 
   renderBodyEditor = ({ editor, view }) => {
     const { isEditable } = this.state
-    var menubar = isEditable ? menu : annotationMenu
+    var menubar = isEditable ? menu2 : annotationMenu
     return (
       <div>
         <Floater view={view}>
-          <MenuBar menu={menubar} view={view} />
+          <VertMenuBar menu={menubar} view={view} />
         </Floater>
         <div className="post-editor">{editor}</div>
       </div>

--- a/app/javascript/components/VerticalMenuBar.js
+++ b/app/javascript/components/VerticalMenuBar.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import map from 'lodash/map'
+import classnames from 'classnames'
+
+const Button = ({ state, dispatch }) => (item, key) => (
+  <div>
+    <button
+      key={key}
+      className={classnames({
+        button: true,
+        active: item.active && item.active(state),
+      })}
+      id={item.id}
+      title={item.title}
+      disabled={item.enable && !item.enable(state)}
+      onMouseDown={(e) => {
+        if (item.run) {
+          e.preventDefault()
+          item.run(state, dispatch)
+        }
+      }}
+    >
+      {item.content}
+    </button>
+  </div>
+)
+
+const VertMenuBar = ({ menu, children, view }) => (
+  <div>
+    <div className="bar">
+      {children && <span className="group">{children}</span>}
+
+      {map(menu, (item, key) => (
+        <span key={key} className="group">
+          {map(item, Button(view))}
+        </span>
+      ))}
+    </div>
+  </div>
+)
+
+export default VertMenuBar

--- a/app/javascript/components/editor-config/index.js
+++ b/app/javascript/components/editor-config/index.js
@@ -18,3 +18,4 @@ export const titleOptions = {
 export { default as menu } from './menu'
 export { default as annotationMenu } from './annotation-popup'
 export { default as titleMenu } from './title-menu'
+export { default as menu2 } from './menu2'

--- a/app/javascript/components/editor-config/menu.js
+++ b/app/javascript/components/editor-config/menu.js
@@ -56,69 +56,38 @@ const promptForURL = () => {
 }
 
 export default {
-  figures: {
-    addFigure: {
-      title: 'Add Image',
-      id: 'image-button',
-      run: addFigure,
-      // select: state => addFigure(state),
-      content: icons.image,
-    },
-  },
-  comments: {
-    addComment: {
-      title: 'Add Comment',
-      run: addAnnotation,
-      // select: state => addAnnotation(state),
-      content: icons.comment,
-    },
-  },
   marks: {
-    em: {
-      title: 'Toggle emphasis',
-      content: icons.em,
-      active: markActive(schema.marks.em),
-      run: toggleMark(schema.marks.em),
-    },
     strong: {
       title: 'Toggle strong',
-      content: icons.strong,
+      content: 'Bold',
       active: markActive(schema.marks.strong),
       run: toggleMark(schema.marks.strong),
     },
-    code: {
-      title: 'Toggle code',
-      content: icons.code,
-      active: markActive(schema.marks.code),
-      run: toggleMark(schema.marks.code),
+
+    em: {
+      title: 'Toggle emphasis',
+      content: 'Italic',
+      active: markActive(schema.marks.em),
+      run: toggleMark(schema.marks.em),
     },
-    subscript: {
-      title: 'Toggle subscript',
-      content: icons.subscript,
-      active: markActive(schema.marks.subscript),
-      run: toggleMark(schema.marks.subscript),
-    },
-    superscript: {
-      title: 'Toggle superscript',
-      content: icons.superscript,
-      active: markActive(schema.marks.superscript),
-      run: toggleMark(schema.marks.superscript),
-    },
+
     underline: {
       title: 'Toggle underline',
-      content: icons.underline,
+      content: 'Underline',
       active: markActive(schema.marks.underline),
       run: toggleMark(schema.marks.underline),
     },
-    strikethrough: {
-      title: 'Toggle strikethrough',
-      content: icons.strikethrough,
-      active: markActive(schema.marks.strikethrough),
-      run: toggleMark(schema.marks.strikethrough),
+
+    code: {
+      title: 'Toggle code',
+      content: '<code/>',
+      active: markActive(schema.marks.code),
+      run: toggleMark(schema.marks.code),
     },
+
     link: {
       title: 'Add or remove link',
-      content: icons.link,
+      content: 'Link',
       active: markActive(schema.marks.link),
       enable: (state) => !state.selection.empty,
       run(state, dispatch) {
@@ -135,155 +104,251 @@ export default {
       },
     },
   },
-  blocks: {
-    plain: {
-      title: 'Change to paragraph',
-      content: icons.paragraph,
-      active: blockActive(schema.nodes.paragraph),
-      enable: setBlockType(schema.nodes.paragraph),
-      run: setBlockType(schema.nodes.paragraph),
-    },
-    code_block: {
-      title: 'Change to code block',
-      content: icons.code_block,
-      active: blockActive(schema.nodes.code_block),
-      enable: setBlockType(schema.nodes.code_block),
-      run: setBlockType(schema.nodes.code_block),
-    },
-    h1: {
-      title: 'Change to heading level 1',
-      content: icons.heading,
-      active: blockActive(schema.nodes.heading, { level: 1 }),
-      enable: setBlockType(schema.nodes.heading, { level: 1 }),
-      run: setBlockType(schema.nodes.heading, { level: 1 }),
-    },
-    // h2: {
-    //   title: 'Change to heading level 2',
-    //   content: 'H2',
-    //   active: blockActive(schema.nodes.heading, { level: 2 }),
-    //   enable: setBlockType(schema.nodes.heading, { level: 2 }),
-    //   run: setBlockType(schema.nodes.heading, { level: 2 })
-    // },
-    blockquote: {
-      title: 'Wrap in block quote',
-      content: icons.blockquote,
-      active: blockActive(schema.nodes.blockquote),
-      enable: wrapIn(schema.nodes.blockquote),
-      run: wrapIn(schema.nodes.blockquote),
-    },
-    bullet_list: {
-      title: 'Wrap in bullet list',
-      content: icons.bullet_list,
-      active: blockActive(schema.nodes.bullet_list),
-      enable: wrapInList(schema.nodes.bullet_list),
-      run: wrapInList(schema.nodes.bullet_list),
-    },
-    ordered_list: {
-      title: 'Wrap in ordered list',
-      content: icons.ordered_list,
-      active: blockActive(schema.nodes.ordered_list),
-      enable: wrapInList(schema.nodes.ordered_list),
-      run: wrapInList(schema.nodes.ordered_list),
-    },
-    lift: {
-      title: 'Lift out of enclosing block',
-      content: icons.lift,
-      enable: lift,
-      run: lift,
-    },
-    join_up: {
-      title: 'Join with above block',
-      content: icons.join_up,
-      enable: joinUp,
-      run: joinUp,
+
+  comments: {
+    addComment: {
+      title: 'Add Comment',
+      run: addAnnotation,
+      // select: state => addAnnotation(state),
+      content: 'Comment',
     },
   },
-  insert: {
-    // image: {
-    //   title: 'Insert image',
-    //   content: icons.image,
-    //   enable: canInsert(schema.nodes.image),
-    //   run: (state, dispatch) => {
-    //     const src = promptForURL()
-    //     if (!src) return false
 
-    //     const img = schema.nodes.image.createAndFill({ src })
-    //     dispatch(state.tr.replaceSelectionWith(img))
-    //   },
-    // },
-    footnote: {
-      title: 'Insert footnote',
-      content: icons.footnote,
-      enable: canInsert(schema.nodes.footnote),
-      run: (state, dispatch) => {
-        const footnote = schema.nodes.footnote.create()
-        dispatch(state.tr.replaceSelectionWith(footnote))
-      },
-    },
-    // hr: {
-    //   title: 'Insert horizontal rule',
-    //   content: 'HR',
-    //   enable: canInsert(schema.nodes.horizontal_rule),
-    //   run: (state, dispatch) => {
-    //     const hr = schema.nodes.horizontal_rule.create()
-    //     dispatch(state.tr.replaceSelectionWith(hr))
-    //   }
-    // },
-    table: {
-      title: 'Insert table',
-      content: icons.table,
-      enable: canInsert(schema.nodes.table),
-      run: (state, dispatch) => {
-        // const { from } = state.selection
-        let rowCount = window && window.prompt('How many rows?', 2)
-        let colCount = window && window.prompt('How many columns?', 2)
-
-        const cells = []
-        while (colCount--) {
-          cells.push(schema.nodes.table_cell.createAndFill())
-        }
-
-        const rows = []
-        while (rowCount--) {
-          rows.push(schema.nodes.table_row.createAndFill(null, cells))
-        }
-
-        const table = schema.nodes.table.createAndFill(null, rows)
-        dispatch(state.tr.replaceSelectionWith(table))
-
-        // const tr = state.tr.replaceSelectionWith(table)
-        // tr.setSelection(Selection.near(tr.doc.resolve(from)))
-        // dispatch(tr.scrollIntoView())
-        // view.focus()
-      },
+  bidirectional_link: {
+    addBidirectionalLink: {
+      title: 'Link to Post',
+      content: 'Link to Post',
     },
   },
-  history: {
-    undo: {
-      title: 'Undo last change',
-      content: icons.undo,
-      enable: undo,
-      run: undo,
-    },
-    redo: {
-      title: 'Redo last undone change',
-      content: icons.redo,
-      enable: redo,
-      run: redo,
-    },
-  },
-  // table: {
-  // addColumnBefore: {
-  //   title: 'Insert column before',
-  //   content: icons.after,
-  //   active: addColumnBefore, // TOOD: active -> select
-  //   run: addColumnBefore
+
+  // figures: {
+  //   addFigure: {
+  //     title: 'Add Image',
+  //     id: 'image-button',
+  //     run: addFigure,
+  //     // select: state => addFigure(state),
+  //     content: icons.image,
+  //   },
   // },
-  // addColumnAfter: {
-  //   title: 'Insert column before',
-  //   content: icons.before,
-  //   active: addColumnAfter, // TOOD: active -> select
-  //   run: addColumnAfter
-  // }
-  // }
+  // comments: {
+  //   addComment: {
+  //     title: 'Add Comment',
+  //     run: addAnnotation,
+  //     // select: state => addAnnotation(state),
+  //     content: icons.comment,
+  //   },
+  // },
+  // marks: {
+  //   em: {
+  //     title: 'Toggle emphasis',
+  //     content: icons.em,
+  //     active: markActive(schema.marks.em),
+  //     run: toggleMark(schema.marks.em),
+  //   },
+  //   strong: {
+  //     title: 'Toggle strong',
+  //     content: icons.strong,
+  //     active: markActive(schema.marks.strong),
+  //     run: toggleMark(schema.marks.strong),
+  //   },
+  //   code: {
+  //     title: 'Toggle code',
+  //     content: icons.code,
+  //     active: markActive(schema.marks.code),
+  //     run: toggleMark(schema.marks.code),
+  //   },
+  //   subscript: {
+  //     title: 'Toggle subscript',
+  //     content: icons.subscript,
+  //     active: markActive(schema.marks.subscript),
+  //     run: toggleMark(schema.marks.subscript),
+  //   },
+  //   superscript: {
+  //     title: 'Toggle superscript',
+  //     content: icons.superscript,
+  //     active: markActive(schema.marks.superscript),
+  //     run: toggleMark(schema.marks.superscript),
+  //   },
+  //   underline: {
+  //     title: 'Toggle underline',
+  //     content: icons.underline,
+  //     active: markActive(schema.marks.underline),
+  //     run: toggleMark(schema.marks.underline),
+  //   },
+  //   strikethrough: {
+  //     title: 'Toggle strikethrough',
+  //     content: icons.strikethrough,
+  //     active: markActive(schema.marks.strikethrough),
+  //     run: toggleMark(schema.marks.strikethrough),
+  //   },
+  //   link: {
+  //     title: 'Add or remove link',
+  //     content: icons.link,
+  //     active: markActive(schema.marks.link),
+  //     enable: (state) => !state.selection.empty,
+  //     run(state, dispatch) {
+  //       if (markActive(schema.marks.link)(state)) {
+  //         toggleMark(schema.marks.link)(state, dispatch)
+  //         return true
+  //       }
+
+  //       const href = promptForURL()
+  //       if (!href) return false
+
+  //       toggleMark(schema.marks.link, { href })(state, dispatch)
+  //       // view.focus()
+  //     },
+  //   },
+  // },
+  // blocks: {
+  //   plain: {
+  //     title: 'Change to paragraph',
+  //     content: icons.paragraph,
+  //     active: blockActive(schema.nodes.paragraph),
+  //     enable: setBlockType(schema.nodes.paragraph),
+  //     run: setBlockType(schema.nodes.paragraph),
+  //   },
+  //   code_block: {
+  //     title: 'Change to code block',
+  //     content: icons.code_block,
+  //     active: blockActive(schema.nodes.code_block),
+  //     enable: setBlockType(schema.nodes.code_block),
+  //     run: setBlockType(schema.nodes.code_block),
+  //   },
+  //   h1: {
+  //     title: 'Change to heading level 1',
+  //     content: icons.heading,
+  //     active: blockActive(schema.nodes.heading, { level: 1 }),
+  //     enable: setBlockType(schema.nodes.heading, { level: 1 }),
+  //     run: setBlockType(schema.nodes.heading, { level: 1 }),
+  //   },
+  //   // h2: {
+  //   //   title: 'Change to heading level 2',
+  //   //   content: 'H2',
+  //   //   active: blockActive(schema.nodes.heading, { level: 2 }),
+  //   //   enable: setBlockType(schema.nodes.heading, { level: 2 }),
+  //   //   run: setBlockType(schema.nodes.heading, { level: 2 })
+  //   // },
+  //   blockquote: {
+  //     title: 'Wrap in block quote',
+  //     content: icons.blockquote,
+  //     active: blockActive(schema.nodes.blockquote),
+  //     enable: wrapIn(schema.nodes.blockquote),
+  //     run: wrapIn(schema.nodes.blockquote),
+  //   },
+  //   bullet_list: {
+  //     title: 'Wrap in bullet list',
+  //     content: icons.bullet_list,
+  //     active: blockActive(schema.nodes.bullet_list),
+  //     enable: wrapInList(schema.nodes.bullet_list),
+  //     run: wrapInList(schema.nodes.bullet_list),
+  //   },
+  //   ordered_list: {
+  //     title: 'Wrap in ordered list',
+  //     content: icons.ordered_list,
+  //     active: blockActive(schema.nodes.ordered_list),
+  //     enable: wrapInList(schema.nodes.ordered_list),
+  //     run: wrapInList(schema.nodes.ordered_list),
+  //   },
+  //   lift: {
+  //     title: 'Lift out of enclosing block',
+  //     content: icons.lift,
+  //     enable: lift,
+  //     run: lift,
+  //   },
+  //   join_up: {
+  //     title: 'Join with above block',
+  //     content: icons.join_up,
+  //     enable: joinUp,
+  //     run: joinUp,
+  //   },
+  // },
+  // insert: {
+  //   // image: {
+  //   //   title: 'Insert image',
+  //   //   content: icons.image,
+  //   //   enable: canInsert(schema.nodes.image),
+  //   //   run: (state, dispatch) => {
+  //   //     const src = promptForURL()
+  //   //     if (!src) return false
+
+  //   //     const img = schema.nodes.image.createAndFill({ src })
+  //   //     dispatch(state.tr.replaceSelectionWith(img))
+  //   //   },
+  //   // },
+  //   footnote: {
+  //     title: 'Insert footnote',
+  //     content: icons.footnote,
+  //     enable: canInsert(schema.nodes.footnote),
+  //     run: (state, dispatch) => {
+  //       const footnote = schema.nodes.footnote.create()
+  //       dispatch(state.tr.replaceSelectionWith(footnote))
+  //     },
+  //   },
+  //   // hr: {
+  //   //   title: 'Insert horizontal rule',
+  //   //   content: 'HR',
+  //   //   enable: canInsert(schema.nodes.horizontal_rule),
+  //   //   run: (state, dispatch) => {
+  //   //     const hr = schema.nodes.horizontal_rule.create()
+  //   //     dispatch(state.tr.replaceSelectionWith(hr))
+  //   //   }
+  //   // },
+  //   table: {
+  //     title: 'Insert table',
+  //     content: icons.table,
+  //     enable: canInsert(schema.nodes.table),
+  //     run: (state, dispatch) => {
+  //       // const { from } = state.selection
+  //       let rowCount = window && window.prompt('How many rows?', 2)
+  //       let colCount = window && window.prompt('How many columns?', 2)
+
+  //       const cells = []
+  //       while (colCount--) {
+  //         cells.push(schema.nodes.table_cell.createAndFill())
+  //       }
+
+  //       const rows = []
+  //       while (rowCount--) {
+  //         rows.push(schema.nodes.table_row.createAndFill(null, cells))
+  //       }
+
+  //       const table = schema.nodes.table.createAndFill(null, rows)
+  //       dispatch(state.tr.replaceSelectionWith(table))
+
+  //       // const tr = state.tr.replaceSelectionWith(table)
+  //       // tr.setSelection(Selection.near(tr.doc.resolve(from)))
+  //       // dispatch(tr.scrollIntoView())
+  //       // view.focus()
+  //     },
+  //   },
+  // },
+  // history: {
+  //   undo: {
+  //     title: 'Undo last change',
+  //     content: icons.undo,
+  //     enable: undo,
+  //     run: undo,
+  //   },
+  //   redo: {
+  //     title: 'Redo last undone change',
+  //     content: icons.redo,
+  //     enable: redo,
+  //     run: redo,
+  //   },
+  // },
+  // // table: {
+  // // addColumnBefore: {
+  // //   title: 'Insert column before',
+  // //   content: icons.after,
+  // //   active: addColumnBefore, // TOOD: active -> select
+  // //   run: addColumnBefore
+  // // },
+  // // addColumnAfter: {
+  // //   title: 'Insert column before',
+  // //   content: icons.before,
+  // //   active: addColumnAfter, // TOOD: active -> select
+  // //   run: addColumnAfter
+  // // }
+  // // }
 }

--- a/app/javascript/components/editor-config/menu2.js
+++ b/app/javascript/components/editor-config/menu2.js
@@ -56,70 +56,6 @@ const promptForURL = () => {
 }
 
 export default {
-  comments: {
-    addComment: {
-      title: 'Add Comment',
-      run: addAnnotation,
-      // select: state => addAnnotation(state),
-      content: 'Comment',
-    },
-  },
-  marks: {
-    strong: {
-      title: 'Toggle strong',
-      content: 'Bold',
-      active: markActive(schema.marks.strong),
-      run: toggleMark(schema.marks.strong),
-    },
-
-    em: {
-      title: 'Toggle emphasis',
-      content: 'Italic',
-      active: markActive(schema.marks.em),
-      run: toggleMark(schema.marks.em),
-    },
-
-    underline: {
-      title: 'Toggle underline',
-      content: 'Underline',
-      active: markActive(schema.marks.underline),
-      run: toggleMark(schema.marks.underline),
-    },
-
-    code: {
-      title: 'Toggle code',
-      content: '<code/>',
-      active: markActive(schema.marks.code),
-      run: toggleMark(schema.marks.code),
-    },
-
-    link: {
-      title: 'Add or remove link',
-      content: 'Link',
-      active: markActive(schema.marks.link),
-      enable: (state) => !state.selection.empty,
-      run(state, dispatch) {
-        if (markActive(schema.marks.link)(state)) {
-          toggleMark(schema.marks.link)(state, dispatch)
-          return true
-        }
-
-        const href = promptForURL()
-        if (!href) return false
-
-        toggleMark(schema.marks.link, { href })(state, dispatch)
-        // view.focus()
-      },
-    },
-  },
-
-  bidirectional_link: {
-    addBidirectionalLink: {
-      title: 'Link to Post',
-      content: 'Link to Post',
-    },
-  },
-
   // figures: {
   //   addFigure: {
   //     title: 'Add Image',
@@ -140,19 +76,19 @@ export default {
   // marks: {
   //   em: {
   //     title: 'Toggle emphasis',
-  //     content: icons.em,
+  //     content: 'Italic',
   //     active: markActive(schema.marks.em),
   //     run: toggleMark(schema.marks.em),
   //   },
   //   strong: {
   //     title: 'Toggle strong',
-  //     content: icons.strong,
+  //     content: 'Bold',
   //     active: markActive(schema.marks.strong),
   //     run: toggleMark(schema.marks.strong),
   //   },
   //   code: {
   //     title: 'Toggle code',
-  //     content: icons.code,
+  //     content: '<code/>',
   //     active: markActive(schema.marks.code),
   //     run: toggleMark(schema.marks.code),
   //   },
@@ -199,6 +135,86 @@ export default {
   //     },
   //   },
   // },
+  blocks: {
+    h2: {
+      title: 'Change to heading level 2',
+      content: 'Heading 2',
+      active: blockActive(schema.nodes.heading, { level: 2 }),
+      enable: setBlockType(schema.nodes.heading, { level: 2 }),
+      run: setBlockType(schema.nodes.heading, { level: 2 }),
+    },
+    h3: {
+      title: 'Change to heading level 3',
+      content: 'Heading 3',
+      active: blockActive(schema.nodes.heading, { level: 2 }),
+      enable: setBlockType(schema.nodes.heading, { level: 2 }),
+      run: setBlockType(schema.nodes.heading, { level: 2 }),
+    },
+    h4: {
+      title: 'Change to heading level 2',
+      content: 'Heading 4',
+      active: blockActive(schema.nodes.heading, { level: 2 }),
+      enable: setBlockType(schema.nodes.heading, { level: 2 }),
+      run: setBlockType(schema.nodes.heading, { level: 2 }),
+    },
+    ordered_list: {
+      title: 'Wrap in ordered list',
+      content: 'Numbered List',
+      active: blockActive(schema.nodes.ordered_list),
+      enable: wrapInList(schema.nodes.ordered_list),
+      run: wrapInList(schema.nodes.ordered_list),
+    },
+    bullet_list: {
+      title: 'Wrap in bullet list',
+      content: 'Bulleted List',
+      active: blockActive(schema.nodes.bullet_list),
+      enable: wrapInList(schema.nodes.bullet_list),
+      run: wrapInList(schema.nodes.bullet_list),
+    },
+    blockquote: {
+      title: 'Wrap in block quote',
+      content: 'Blockquote',
+      active: blockActive(schema.nodes.blockquote),
+      enable: wrapIn(schema.nodes.blockquote),
+      run: wrapIn(schema.nodes.blockquote),
+    },
+    code_block: {
+      title: 'Change to code block',
+      content: 'Codeblock',
+      active: blockActive(schema.nodes.code_block),
+      enable: setBlockType(schema.nodes.code_block),
+      run: setBlockType(schema.nodes.code_block),
+    },
+    strong: {
+      title: 'Toggle strong',
+      content: 'Bold',
+    },
+    em: {
+      title: 'Toggle strong',
+      content: 'Italic',
+    },
+    code: {
+      title: 'Toggle code',
+      content: '<code/>',
+    },
+    figure: {
+      title: 'Upload figure',
+      content: 'Figure',
+    },
+    upload_pdf: {
+      title: 'Upload a PDF',
+      content: 'Upload a PDF',
+    },
+    bidirectional_link: {
+      title: 'Link to post',
+      content: 'Link to post',
+    },
+    equation: {
+      title: 'Change to equation block',
+      content: 'LaTeX',
+    },
+  },
+
   // blocks: {
   //   plain: {
   //     title: 'Change to paragraph',
@@ -207,48 +223,7 @@ export default {
   //     enable: setBlockType(schema.nodes.paragraph),
   //     run: setBlockType(schema.nodes.paragraph),
   //   },
-  //   code_block: {
-  //     title: 'Change to code block',
-  //     content: icons.code_block,
-  //     active: blockActive(schema.nodes.code_block),
-  //     enable: setBlockType(schema.nodes.code_block),
-  //     run: setBlockType(schema.nodes.code_block),
-  //   },
-  //   h1: {
-  //     title: 'Change to heading level 1',
-  //     content: icons.heading,
-  //     active: blockActive(schema.nodes.heading, { level: 1 }),
-  //     enable: setBlockType(schema.nodes.heading, { level: 1 }),
-  //     run: setBlockType(schema.nodes.heading, { level: 1 }),
-  //   },
-  //   // h2: {
-  //   //   title: 'Change to heading level 2',
-  //   //   content: 'H2',
-  //   //   active: blockActive(schema.nodes.heading, { level: 2 }),
-  //   //   enable: setBlockType(schema.nodes.heading, { level: 2 }),
-  //   //   run: setBlockType(schema.nodes.heading, { level: 2 })
-  //   // },
-  //   blockquote: {
-  //     title: 'Wrap in block quote',
-  //     content: icons.blockquote,
-  //     active: blockActive(schema.nodes.blockquote),
-  //     enable: wrapIn(schema.nodes.blockquote),
-  //     run: wrapIn(schema.nodes.blockquote),
-  //   },
-  //   bullet_list: {
-  //     title: 'Wrap in bullet list',
-  //     content: icons.bullet_list,
-  //     active: blockActive(schema.nodes.bullet_list),
-  //     enable: wrapInList(schema.nodes.bullet_list),
-  //     run: wrapInList(schema.nodes.bullet_list),
-  //   },
-  //   ordered_list: {
-  //     title: 'Wrap in ordered list',
-  //     content: icons.ordered_list,
-  //     active: blockActive(schema.nodes.ordered_list),
-  //     enable: wrapInList(schema.nodes.ordered_list),
-  //     run: wrapInList(schema.nodes.ordered_list),
-  //   },
+
   //   lift: {
   //     title: 'Lift out of enclosing block',
   //     content: icons.lift,

--- a/app/javascript/components/editor-config/title-menu.js
+++ b/app/javascript/components/editor-config/title-menu.js
@@ -15,33 +15,33 @@ export default {
   comments: {
     addComment: {
       title: 'Add Comment',
-      run: addAnnotation,
+      run: 'addAnnotation',
       // select: state => addAnnotation(state),
-      content: icons.comment,
+      content: 'Comment',
     },
   },
   marks: {
     em: {
       title: 'Toggle emphasis',
-      content: icons.em,
+      content: 'Italics',
       active: markActive(schema.marks.em),
       run: toggleMark(schema.marks.em),
     },
     code: {
       title: 'Toggle code',
-      content: icons.code,
+      content: '<code/>',
       active: markActive(schema.marks.code),
       run: toggleMark(schema.marks.code),
     },
     subscript: {
       title: 'Toggle subscript',
-      content: icons.subscript,
+      content: 'Subscript',
       active: markActive(schema.marks.subscript),
       run: toggleMark(schema.marks.subscript),
     },
     superscript: {
       title: 'Toggle superscript',
-      content: icons.superscript,
+      content: 'Superscript',
       active: markActive(schema.marks.superscript),
       run: toggleMark(schema.marks.superscript),
     },


### PR DESCRIPTION
the goal is to create two menu bars

menu bar 1:
![85931825-cd5dbe00-b862-11ea-8920-419576281ed0](https://user-images.githubusercontent.com/1177031/85934224-e6bf3400-b87b-11ea-9b21-7da5504be799.png)

menu bar 2:
![85931810-bd45de80-b862-11ea-9c3d-1f9248e88947](https://user-images.githubusercontent.com/1177031/85934236-0a827a00-b87c-11ea-8895-caf2faa6773f.png)

state of menu bar in production:

![Untitled | Jelly 2020-06-27 13-16-19](https://user-images.githubusercontent.com/1177031/85934231-ff2f4e80-b87b-11ea-9ca1-bd8246d7527c.png)



