### PR TITLE
updates slack URLs to use invite URL

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -17,4 +17,4 @@ Please check out the below for how to get involved with this project.
 
 ## Asking Questions
 
-Join our slack at [http://jelly-community.slack.com](http://jelly-community.slack.com), or follow along with general things at [http://jellypbc.com](http://jellypbc.com).
+Join our slack at [http://jelly-community.slack.com](https://join.slack.com/t/jelly-community/shared_invite/zt-gldzxtjm-an~oC_8YCjvQScUGaBbj6Q), or follow along with general things at [http://jellypbc.com](http://jellypbc.com).

--- a/app/views/pages/about.html.slim
+++ b/app/views/pages/about.html.slim
@@ -9,7 +9,7 @@
       br
       .contact-us
         = link_to "blog |", "http://jellypbc.com", target: '_blank'
-        = link_to " slack |", "https://jellypbc.com/follow", target: '_blank'
+        = link_to " slack |", "https://join.slack.com/t/jelly-community/shared_invite/zt-gldzxtjm-an~oC_8YCjvQScUGaBbj6Q", target: '_blank'
         = link_to " twitter |", "http://twitter.com/jellypbc", target: '_blank'
         = link_to " github |", "http://github.com/jellypbc", target: '_blank'
         = mail_to "aloha@jellypbc.com", " email"

--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -16,7 +16,7 @@
               = " | "
               = link_to 'Twitter', "http://twitter.com/jellypbc", target: '_blank'
               = " | "
-              = link_to 'Slack', "http://jelly-community.slack.com", target: '_blank'
+              = link_to 'Slack', "https://join.slack.com/t/jelly-community/shared_invite/zt-gldzxtjm-an~oC_8YCjvQScUGaBbj6Q", target: '_blank'
               = " | "
               = link_to 'GitHub', "https://github.com/jellypbc", target: '_blank'
               = " | "


### PR DESCRIPTION
fixes https://github.com/jellypbc/poster/issues/274

if you are an existing jelly slack member and logged in, clicking the invite URL will take you the slack workspace. 

if you are new, clicking the invite URL will take you to the slack registration flow.