### PR TITLE
Img upload refactor 1

### DIFF
--- a/app/javascript/components/ImageModal.js
+++ b/app/javascript/components/ImageModal.js
@@ -1,9 +1,35 @@
 import React from 'react'
+import { images } from './store'
 import { useSelector, useDispatch } from 'react-redux'
 import Modal from 'react-modal'
 import Uppy from '@uppy/core'
 import XHRUpload from '@uppy/xhr-upload'
 import { DragDrop } from '@uppy/react'
+
+// React Hook that manages Uppy instances for uploading
+function useUppy(token, onUpload) {
+  const [uploaderGeneration, setUploaderGeneration] = React.useState(0)
+  return React.useMemo(() => {
+    const _uppy = Uppy({
+      meta: { type: 'figure' },
+      restrictions: { maxNumberOfFiles: 1 },
+      autoProceed: true,
+    }).use(XHRUpload, {
+      endpoint: '/images/store',
+      bundle: true,
+      headers: {
+        csrf: token,
+      },
+    })
+    _uppy.on('complete', (result) => {
+      const fileUrl = result.successful[0].response.body.url
+      onUpload(fileUrl)
+      // build a new Uppy instance for the next upload
+      setUploaderGeneration(uploaderGeneration + 1)
+    })
+    return _uppy
+  }, [onUpload, token, uploaderGeneration])
+}
 
 function ImageModal() {
   const dispatch = useDispatch()
@@ -11,32 +37,19 @@ function ImageModal() {
 
   const token = document.head.querySelector('[name~=csrf-token][content]')
     .content
-
-  var uppy = Uppy({
-    meta: { type: 'figure' },
-    restrictions: { maxNumberOfFiles: 1 },
-    autoProceed: true,
-  }).use(XHRUpload, {
-    endpoint: '/images/store',
-    bundle: true,
-    headers: {
-      csrf: token,
+  const handleUpload = React.useCallback(
+    (fileUrl) => {
+      dispatch(images.actions.addImageSuccess({ fileUrl: fileUrl }))
     },
-  })
-
-  uppy.on('complete', (result) => {
-    const fileUrl = result.successful[0].response.body.url
-    dispatch({
-      type: 'addImageSuccess',
-      payload: { fileUrl: fileUrl },
-    })
-  })
+    [dispatch]
+  )
+  const uppy = useUppy(token, handleUpload)
 
   return (
     <div>
       <Modal
         onRequestClose={() => {
-          dispatch({ type: 'closeImageModal' })
+          dispatch(images.actions.closeImageModal())
         }}
         className="image-modal-container"
         shouldCloseOnOverlayClick={true}

--- a/app/javascript/components/editor-config/images.js
+++ b/app/javascript/components/editor-config/images.js
@@ -1,21 +1,24 @@
-import { store } from '../store'
-import { schema } from './schema'
+import { store, images, waitForStore, TIMEOUT_ERROR } from '../store'
+import schema from './schema'
 
-export const addFigure = function (state, dispatch) {
-  console.log(state)
-  if (dispatch) {
-    // we're now in redux land, and no longer in PM land
-    store.dispatch({
-      type: 'addImageStart',
-      payload: {
-        onImageAddSuccess: (action) => {
-          var imageUrl = action.payload.fileUrl
-          var imageType = schema.nodes.image
-          let tr = state.tr
-          dispatch(tr.replaceSelectionWith(imageType.create({ src: imageUrl })))
-          return true
-        },
-      },
+// note: "pm" = ProseMirror, "store" = app-wide redux store
+export const addFigure = function (pmState, pmDispatch) {
+  if (!pmDispatch) return true
+
+  store.dispatch(images.actions.addImageStart())
+
+  waitForStore({
+    selector: (storeState) => storeState.images,
+    succeed: (images) => !images.isAddingImage && images.lastImage,
+    fail: (images) => !images.isAddingImage && !images.lastImage,
+    timeout: 1000 * 30,
+  })
+    .then((imageStoreState) => {
+      const imageUrl = imageStoreState.lastImage.fileUrl
+      const imageType = schema.nodes.image
+      pmDispatch(
+        pmState.tr.replaceSelectionWith(imageType.create({ src: imageUrl }))
+      )
     })
   }
   return true

--- a/app/javascript/components/editor-config/images.js
+++ b/app/javascript/components/editor-config/images.js
@@ -1,5 +1,5 @@
 import { store, images, waitForStore, TIMEOUT_ERROR } from '../store'
-import schema from './schema'
+import { schema } from './schema'
 
 // note: "pm" = ProseMirror, "store" = app-wide redux store
 export const addFigure = function (pmState, pmDispatch) {
@@ -12,14 +12,13 @@ export const addFigure = function (pmState, pmDispatch) {
     succeed: (images) => !images.isAddingImage && images.lastImage,
     fail: (images) => !images.isAddingImage && !images.lastImage,
     timeout: 1000 * 30,
+  }).then((imageStoreState) => {
+    const imageUrl = imageStoreState.lastImage.fileUrl
+    const imageType = schema.nodes.image
+    pmDispatch(
+      pmState.tr.replaceSelectionWith(imageType.create({ src: imageUrl }))
+    )
   })
-    .then((imageStoreState) => {
-      const imageUrl = imageStoreState.lastImage.fileUrl
-      const imageType = schema.nodes.image
-      pmDispatch(
-        pmState.tr.replaceSelectionWith(imageType.create({ src: imageUrl }))
-      )
-    })
-  }
+
   return true
 }

--- a/app/javascript/components/store.js
+++ b/app/javascript/components/store.js
@@ -1,4 +1,4 @@
-import { configureStore, createReducer } from '@reduxjs/toolkit'
+import { configureStore, createReducer, createSlice } from '@reduxjs/toolkit'
 
 // unsafe side-effects for comment actions
 const commentsEffects = {
@@ -46,32 +46,26 @@ const commentReducers = {
   },
 }
 
-const imagesEffects = {
-  onImageAddSuccess: (payload) => {},
-}
-
-const imagesReducerDefaultState = {
-  isAddingimage: false,
-}
-
-const imageReducers = {
-  addImageStart: (state, action) => {
-    state.isAddingImage = true
-    // runs the images plugin onImageAddSuccess() payload
-    if (action.payload.onImageAddSuccess) {
-      imagesEffects.onImageAddSuccess = action.payload.onImageAddSuccess
-    }
+const images = createSlice({
+  name: 'images',
+  initialState: {
+    isAddingimage: false,
+    lastImage: null,
   },
-  addImageSuccess: (state, action) => {
-    if (imagesEffects.onImageAddSuccess) {
-      imagesEffects.onImageAddSuccess(action)
-    }
-    state.isAddingImage = false
+  reducers: {
+    addImageStart: (state, action) => {
+      state.lastImage = null
+      state.isAddingImage = true
+    },
+    addImageSuccess: (state, action) => {
+      state.lastImage = action.payload
+      state.isAddingImage = false
+    },
+    closeImageModal: (state, action) => {
+      state.isAddingImage = false
+    },
   },
-  closeImageModal: (state, action) => {
-    state.isAddingImage = false
-  },
-}
+})
 
 const postReducers = {
   setCurrentPost: (state, action) => {
@@ -88,13 +82,75 @@ const userReducers = {
 const store = configureStore({
   reducer: {
     comments: createReducer(commentsReducerDefaultState, commentReducers),
-    images: createReducer(imagesReducerDefaultState, imageReducers),
     currentPost: createReducer({}, postReducers),
     currentUser: createReducer({}, userReducers),
+    images: images.reducer,
   },
 })
 
 // for debugging
 window._store = store
 
-export { store }
+/**
+ * Function to create a store observer
+ * @param {(State | SelectorResult) => any} onChange - function to call on state change
+ * @param {{}} [options] - options object
+ * @param {(State) => SelectorResult} [options.selector] - optional function to transform the store state
+ * @returns {{ unsubscribe: () => void }} object with an unsubscribe method
+ */
+function observeStore(onChange, { selector = (state) => state } = {}) {
+  let currentState
+  function handleChange() {
+    // Using a selector function lets us subscribe to changes in just a slice of
+    // the store (defaults to the whole thing if no selector is provided):
+    let nextState = selector(store.getState())
+    if (nextState !== currentState) {
+      currentState = nextState
+      onChange(currentState)
+    }
+  }
+  return { unsubscribe: store.subscribe(handleChange) }
+}
+
+// exported in case you need to check the reason the condition failed
+const TIMEOUT_ERROR = 'condition_timed_out'
+
+/**
+ * @example await waitForStore({ selector: state => state.posts[0], timeout: 1000, succeed: newPost => newPost.isCreating === false})
+ * @returns {Promise} - Promise that resolves when succeed option returns true, and rejects if it times out or fail option returns true
+ * @param {{}} [options] - options object
+ * @param {(SelectorResult) => boolean} [options.succeed] - take selector result and returns true if promise should resolve
+ * @param {(SelectorResult) => boolean} [options.fail] - take selector result and returns true if promise should reject
+ * @param {(State) => SelectorResult} [options.selector] - optional function to transform the store state
+ * @param {number} [options.timeout] how long to wait before rejecting automatically
+ */
+function waitForStore({
+  succeed = () => false,
+  fail = () => false,
+  timeout = 5000,
+  selector = (state) => state,
+} = {}) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    let observerRef = { current: { unsubscribe: () => {} } }
+    const timer = setTimeout(() => {
+      observerRef.current.unsubscribe()
+      rejectPromise(new Error(TIMEOUT_ERROR))
+    }, timeout)
+    const finish = () => {
+      observerRef.current.unsubscribe()
+      clearTimeout(timer)
+    }
+    const onChange = (state) => {
+      if (succeed(state)) {
+        finish()
+        resolvePromise(state)
+      } else if (fail(state)) {
+        finish()
+        rejectPromise(state)
+      }
+    }
+    observerRef.current = observeStore(onChange, { selector })
+  })
+}
+
+export { store, images, observeStore, waitForStore, TIMEOUT_ERROR }


### PR DESCRIPTION
Rebased @alexkrolick's original PR (https://github.com/jellypbc/poster/pull/151).

This PR sets up a pattern that we can follow for using redux with prosemirror 'dispatching'. It uses redux toolkit's `createSlice` for a neat and orderly pattern.