### PR TITLE
Fixes ordered_list and bullet_list node types in editor

### DIFF
--- a/app/javascript/components/editor-config/nodes.js
+++ b/app/javascript/components/editor-config/nodes.js
@@ -14,17 +14,6 @@ const nodes = {
     content: 'block+',
   },
 
-  header: {
-    attrs: { level: { default: 0 } },
-    content: 'inline*',
-    group: 'block',
-    defining: true,
-    parseDOM: [{ tag: 'head', preserveWhitespace: false }],
-    toDOM() {
-      return ['p', 0]
-    },
-  },
-
   // :: NodeSpec A plain paragraph textblock. Represented in the DOM
   // as a `<p>` element.
   paragraph: {


### PR DESCRIPTION
This PR removes the `header` node type and leaves the `heading` node type. 

Because the `header` node type is removed, new lines in the editor default to the `paragraph` node type instead of `header`. Because `ordered_list` and `bullet_list` node types [require the first child of a list item is a plain paragraph](https://prosemirror.net/docs/ref/#schema-list), having new lines in the editor default to `paragraph` allow markdown and menu buttons commands to create list nodes.

fixes one item in https://github.com/jellypbc/poster/issues/232

https://www.loom.com/share/2f58ee401192422bbd9e7a4b827ba51e?focus_title=1&muted=1