### PR TITLE
Refactor and polish placeholder plugin

### DIFF
--- a/app/assets/stylesheets/editor.scss
+++ b/app/assets/stylesheets/editor.scss
@@ -3,6 +3,7 @@
 @import 'editor/floater';
 @import 'editor/menubar';
 @import 'editor/sidebar';
+@import 'editor/placeholder';
 
 a:hover {
   text-decoration: underline;

--- a/app/assets/stylesheets/editor/placeholder.scss
+++ b/app/assets/stylesheets/editor/placeholder.scss
@@ -17,3 +17,11 @@
 .post-editor .ProseMirror table p.empty-node:only-child::before {
   content: none;
 }
+
+.post-editor .ProseMirror ul p.empty-node:only-child::before {
+  content: none;
+}
+
+.post-editor .ProseMirror ol p.empty-node:only-child::before {
+  content: none;
+}

--- a/app/assets/stylesheets/editor/placeholder.scss
+++ b/app/assets/stylesheets/editor/placeholder.scss
@@ -1,11 +1,15 @@
 .ProseMirror .empty-node::before {
-  float: left;
   color: #aaa;
   pointer-events: none;
   height: 0;
-  font-style: italic;
 }
 
-.ProseMirror p.empty-node:first-child::before {
-  content: 'Start typing…';
+.title .ProseMirror p.empty-node:first-child::before {
+  float: center;
+  content: 'Untitled';
+}
+
+.post-editor .ProseMirror p.empty-node:only-child::before {
+  float: left;
+  content: 'Start typing...';
 }

--- a/app/assets/stylesheets/editor/placeholder.scss
+++ b/app/assets/stylesheets/editor/placeholder.scss
@@ -13,3 +13,7 @@
   float: left;
   content: 'Start typing...';
 }
+
+.post-editor .ProseMirror table p.empty-node:only-child::before {
+  content: none;
+}

--- a/app/assets/stylesheets/editor/placeholder.scss
+++ b/app/assets/stylesheets/editor/placeholder.scss
@@ -1,0 +1,11 @@
+.ProseMirror .empty-node::before {
+  float: left;
+  color: #aaa;
+  pointer-events: none;
+  height: 0;
+  font-style: italic;
+}
+
+.ProseMirror p.empty-node:first-child::before {
+  content: 'Start typing…';
+}

--- a/app/javascript/components/editor-config/placeholder.js
+++ b/app/javascript/components/editor-config/placeholder.js
@@ -1,7 +1,7 @@
 import { Plugin } from 'prosemirror-state'
 import { Decoration, DecorationSet } from 'prosemirror-view'
 
-export default () => {
+export function placeholder() {
   return new Plugin({
     props: {
       decorations: (state) => {

--- a/app/javascript/components/editor-config/placeholder.js
+++ b/app/javascript/components/editor-config/placeholder.js
@@ -1,0 +1,26 @@
+import { Plugin } from 'prosemirror-state'
+import { Decoration, DecorationSet } from 'prosemirror-view'
+
+export default () => {
+  return new Plugin({
+    props: {
+      decorations: (state) => {
+        const decorations = []
+
+        const decorate = (node, pos) => {
+          if (node.type.isBlock && node.childCount === 0) {
+            decorations.push(
+              Decoration.node(pos, pos + node.nodeSize, {
+                class: 'empty-node',
+              })
+            )
+          }
+        }
+
+        state.doc.descendants(decorate)
+
+        return DecorationSet.create(state.doc, decorations)
+      },
+    },
+  })
+}

--- a/app/javascript/components/editor-config/plugins.js
+++ b/app/javascript/components/editor-config/plugins.js
@@ -5,15 +5,14 @@ import { columnResizing, tableEditing } from 'prosemirror-tables'
 import { commentPlugin, commentUI } from './comments'
 import { selectPlugin } from './select'
 import { citationPlugin, citationUI } from './citations'
+import { default as placeholder } from './placeholder'
 
 // TODO: move directly into components
-import { placeholder } from '@aeaton/prosemirror-placeholder'
 import { footnotes } from '@aeaton/prosemirror-footnotes'
 
 // import 'prosemirror-tables/style/tables.css'
 import 'prosemirror-gapcursor/style/gapcursor.css'
 import '@aeaton/prosemirror-footnotes/style/footnotes.css'
-import '@aeaton/prosemirror-placeholder/style/placeholder.css'
 
 import keys from './keys'
 import rules from './rules'

--- a/app/javascript/components/editor-config/plugins.js
+++ b/app/javascript/components/editor-config/plugins.js
@@ -5,7 +5,7 @@ import { columnResizing, tableEditing } from 'prosemirror-tables'
 import { commentPlugin, commentUI } from './comments'
 import { selectPlugin } from './select'
 import { citationPlugin, citationUI } from './citations'
-import { default as placeholder } from './placeholder'
+import { placeholder } from './placeholder'
 
 // TODO: move directly into components
 import { footnotes } from '@aeaton/prosemirror-footnotes'


### PR DESCRIPTION
This PR includes placeholder style changes. 

https://www.loom.com/share/3bbbb03cf0dc4c669d2e71aa3528c32b

fixes https://github.com/jellypbc/poster/issues/283

refactor items:
- [x] create placeholder.scss file and remove css import in plugins.js
- [x] create placeholder.js file and remove placeholder plugin import

polish items:
- [x] center title placeholder
- [x] set title placeholder to 'Untitled'
- [x] remove italics from placeholder styles
- [x] place cursor at beginning of placeholder text for body editor
- [x] remove placeholder when subsequent blocks are present  
- [x] replace export default with export placeholder in placeholder.js
- [x] remove placeholder text from empty boxes in a table element