### PR TITLE
Updates sidebar styles for lists and headings

### DIFF
--- a/app/assets/stylesheets/editor/sidebar.scss
+++ b/app/assets/stylesheets/editor/sidebar.scss
@@ -36,6 +36,7 @@
     h2, h3, h4 {
       font-size: 3px;
       line-height: 4px;
+      letter-spacing: -0.1em;
     }
     p, strong, li, a {
       font-size: 2px;
@@ -55,6 +56,17 @@
     code {
       font-size: 2px;
       line-height: 0;
+    }
+    li {
+      margin: 2px 0px;
+    }
+    ol {
+      padding-left: 4px;
+      margin-bottom: 4px;
+    }
+    ul {
+      padding-left: 4px;
+      margin-bottom: 4px;
     }
     .math-block {
       font-size: 2px;


### PR DESCRIPTION
- [x] decreases padding-left from 30px to 4px for `ul` and `ol` in sidebar
- [x] minimizes letter-spacing to `h2` `h3` `h4` in sidebar

this PR addresses https://github.com/jellypbc/poster/issues/262 but does not fully fix.

![Kapture 2020-10-01 at 16 16 35](https://user-images.githubusercontent.com/1177031/94881612-a387da80-0401-11eb-9f3b-0cd1c75b0868.gif)
