### PR TITLE
Matches post editor styles with post placeholder styles

### DIFF
--- a/app/assets/stylesheets/editor/masthead.scss
+++ b/app/assets/stylesheets/editor/masthead.scss
@@ -42,7 +42,6 @@
     text-align: center;
     margin: 14px auto;
     color: #a0aba5;
-    // background: #e8efed;
     background: $white;
     position: relative;
     width: 60px;
@@ -50,6 +49,9 @@
     border-radius: 4px;
     font-size: 10px;
     line-height: 17px;
+    a {
+      color: #a0aba5;
+    }
 
     &:hover {
       color: #56635c;

--- a/app/assets/stylesheets/editor/masthead.scss
+++ b/app/assets/stylesheets/editor/masthead.scss
@@ -22,6 +22,9 @@
         line-height: 22px;
         font-size: 14px;
       }
+      h1.title-placeholder {
+        color: $grayLight;
+      }
     }
   }
 
@@ -31,7 +34,7 @@
     }
     font-size: 16px;
     a, a:hover {
-      color: #bbb;
+      color: $grayLighter;
     }
     display: block;
     margin: 0 auto;
@@ -41,7 +44,7 @@
   .upload {
     text-align: center;
     margin: 14px auto;
-    color: #a0aba5;
+    color: $grayLight;
     background: $white;
     position: relative;
     width: 60px;
@@ -50,11 +53,11 @@
     font-size: 10px;
     line-height: 17px;
     a {
-      color: #a0aba5;
+      color: $grayLight;
     }
 
     &:hover {
-      color: #56635c;
+      background-color: $grayLighterer;
       transition-duration: 0.2s;
     }
   }

--- a/app/assets/stylesheets/editor/placeholder.scss
+++ b/app/assets/stylesheets/editor/placeholder.scss
@@ -1,5 +1,5 @@
 .ProseMirror .empty-node::before {
-  color: #aaa;
+  color: $grayLight;
   pointer-events: none;
   height: 0;
 }

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -91,8 +91,12 @@
     }
 
   	.figure-caption {
-  		color: $shaleLight;
-  	}
+      color: $shaleLight;
+    }
+
+    .body-placeholder {
+      color: $grayLight;
+    }
   }
 
 	.authors {
@@ -184,4 +188,3 @@
     }
   }
 }
-

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -63,7 +63,7 @@
   .post-editor {
   	p,
   	a,
-		li, {
+		li {
   		font-size: 15px;
   		line-height: 1.55;
       font-weight: 400;

--- a/app/javascript/components/Backlinks.js
+++ b/app/javascript/components/Backlinks.js
@@ -40,6 +40,7 @@ function Backlinks({ backlinks }) {
     rendered = (
       <div className="backlinks my-5">
         <h4 className="my-3">Backlinks</h4>
+        <hr />
         {renderBacklinks(backlinks)}
       </div>
     )

--- a/app/javascript/components/Citations.js
+++ b/app/javascript/components/Citations.js
@@ -46,6 +46,7 @@ export default function Citations({ citations }) {
     rendered = (
       <div className="citations my-5">
         <h4 className="my-3">References</h4>
+        <hr />
         {renderCitations(citations)}
       </div>
     )

--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -31,8 +31,6 @@ import {
   createSerializer,
 } from './postUtils'
 
-import 'prosemirror-view/style/prosemirror.css'
-
 class PostEditor extends React.Component {
   constructor(props) {
     super(props)

--- a/app/javascript/components/PostMasthead.js
+++ b/app/javascript/components/PostMasthead.js
@@ -17,11 +17,7 @@ class PostMasthead extends React.Component {
 
   // TODO: 1. update actions links below (Copy Share Link... etc) 2. put action links into dropdown
   render() {
-    return (
-      <div className="authors">
-        <p>{this.state.authors}</p>
-      </div>
-    )
+    return <div className="authors">{this.state.authors}</div>
   }
 }
 

--- a/app/javascript/components/PostMasthead.js
+++ b/app/javascript/components/PostMasthead.js
@@ -18,8 +18,8 @@ class PostMasthead extends React.Component {
   // TODO: 1. update actions links below (Copy Share Link... etc) 2. put action links into dropdown
   render() {
     return (
-      <div>
-        <p className="authors">{this.state.authors}</p>
+      <div className="authors">
+        <p>{this.state.authors}</p>
       </div>
     )
   }

--- a/app/javascript/components/editor-config/marks.js
+++ b/app/javascript/components/editor-config/marks.js
@@ -71,25 +71,6 @@ const defaultMarks = {
   },
 }
 
-const title = {
-  // :: MarkSpec An emphasis mark. Rendered as an `<em>` element.
-  // Has parse rules that also match `<i>` and `font-style: italic`.
-  em: {
-    parseDOM: [{ tag: 'i' }, { tag: 'em' }, { style: 'font-style=italic' }],
-    toDOM() {
-      return emDOM
-    },
-  },
-
-  // :: MarkSpec Code font mark. Represented as a `<code>` element.
-  code: {
-    parseDOM: [{ tag: 'code' }],
-    toDOM() {
-      return codeDOM
-    },
-  },
-}
-
 const subscript = {
   excludes: 'superscript',
   parseDOM: [{ tag: 'sub' }, { style: 'vertical-align=sub' }],

--- a/app/views/posts/_placeholder_post.html.slim
+++ b/app/views/posts/_placeholder_post.html.slim
@@ -1,22 +1,27 @@
-.placeholder-content
-  .header
-    .header-nav
+.row
+  .col-md-12.placeholder-content.masthead
+    .header
+      .header-nav
+        - if post.uploads.any?
+          .upload.d-flex.justify-content-center
+            - if post.uploads.first.file
+              - if post.uploads.first.file.metadata["mime_type"].include?("image")
+                = image_tag post.uploads.first.file_url
+              - elsif post.uploads.first.file.metadata["mime_type"].include?("pdf")
+                = link_to 'View PDF', post.uploads.first.file_url, target: '_blank'
+        .title
+          h1 = post.title.html_safe if post.title
+        .authors
+          = "authors go here"
 
-      - if post.uploads.any?
-        .pdf-url
-          - if post.uploads.first.file
-            - if post.uploads.first.file.metadata["mime_type"].include?("image")
-              = image_tag post.uploads.first.file_url
-            - elsif post.uploads.first.file.metadata["mime_type"].include?("pdf")
-              = link_to 'View Original PDF', post.uploads.first.file_url, target: '_blank'
-    h1.title
-      = post.title.html_safe if post.title
+  .col-md-2#sidebar
+    #sidebarContainer
+      = "sidebar"
+  .col-md-8.center-column
+    .post-editor
+      = post.body.html_safe if post.body
 
-  br
-  .editor
-    = post.body.html_safe if post.body
-
-  - if post.citations.any?
-    = render 'citations', post: post
-  - if post.backlinks.any?
-    = render 'backlinks', post: post
+    - if post.citations.any?
+      = render 'citations', post: post
+    - if post.backlinks.any?
+      = render 'backlinks', post: post

--- a/app/views/posts/_placeholder_post.html.slim
+++ b/app/views/posts/_placeholder_post.html.slim
@@ -1,5 +1,5 @@
-.row
-  .col-md-12.placeholder-content.masthead
+.row.placeholder-content
+  .col-md-12.masthead
     .header
       .header-nav
         - if post.uploads.any?
@@ -10,16 +10,25 @@
               - elsif post.uploads.first.file.metadata["mime_type"].include?("pdf")
                 = link_to 'View PDF', post.uploads.first.file_url, target: '_blank'
         .title
-          h1 = post.title.html_safe if post.title
+          - if post.title.present? && post.title != "<p></p>"
+            h1 = post.title.html_safe
+          - else 
+            h1.title-placeholder 
+              = "Untitled"
+
         .authors
-          = "authors go here"
+          = post.authors
 
   .col-md-2#sidebar
     #sidebarContainer
-      = "sidebar"
   .col-md-8.center-column
     .post-editor
-      = post.body.html_safe if post.body
+      - if post.body.present? && post.body != "<p></p>"
+        = post.body.html_safe
+      - else 
+        .body-placeholder
+          = "A blank post."
+
 
     - if post.citations.any?
       = render 'citations', post: post


### PR DESCRIPTION
This PR matches visual styles for the placeholder post with the post editor post. The placeholder post will not show a sidebar placeholder.

**after PR:**
placeholder
![image](https://user-images.githubusercontent.com/1177031/96792851-ee5c9880-1396-11eb-9035-852c12f7a228.png)

non-placeholder
![image](https://user-images.githubusercontent.com/1177031/96792866-f61c3d00-1396-11eb-9283-451ef48ca8a6.png)

**before PR:**
placeholder
![image](https://user-images.githubusercontent.com/1177031/96792771-ca00bc00-1396-11eb-9fe6-1ac02d86f6c7.png)

non-placeholder
![image](https://user-images.githubusercontent.com/1177031/96792809-d7b64180-1396-11eb-86f8-f2590002ccea.png)








