### PR TITLE
Hides menubar when no selection and updates threaded comment styles

### DIFF
--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -101,29 +101,7 @@
   }
 }
 
-.j-commentUser {
-  line-height: 18px;
-  margin-bottom: 8px;
-  margin-top: 12px;
-  display: flow-root;
-  width: 100%;
 
-  img {
-    vertical-align: top;
-    border: none;
-    border-radius: 50%;
-    height: 20px;
-    width: 20px;
-    margin-right: 8px;
-    display: inline-block;
-  }
-  .name {
-    color: $black;
-    display: inline;
-    font-weight: 600;
-    word-break: break-all;
-  }
-}
 
 .j-commentForm__input {
   width: 100%;
@@ -176,7 +154,33 @@
   z-index: 10;
   overflow-y: scroll;
   overflow-x: hidden;
+
+  .j-commentUser {
+    line-height: 18px;
+    margin-bottom: 8px;
+    margin-top: 12px;
+    display: flow-root;
+    width: 100%;
+  
+    .name-card {
+      color: $black;
+      display: inline;
+      font-weight: 600;
+      word-break: break-all;
+      img.avatar {
+        vertical-align: top;
+        border: none;
+        border-radius: 50%;
+        height: 20px;
+        width: 20px;
+        margin-right: 8px;
+        display: inline-block;
+        cursor: pointer;
+      }
+    }
+  }
 }
+
 .ProseMirror ul.commentList::-webkit-scrollbar-track {
   -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.05);
   background-color: $white;

--- a/app/javascript/components/CommentForm.js
+++ b/app/javascript/components/CommentForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { store } from '../store'
 import { saRequest } from '../utils/saRequest'
 import { autogrow } from '../utils/autogrow'
@@ -19,14 +19,16 @@ export function CommentForm({
 }) {
   // const dispatch = useDispatch()
   // const comments = useSelector(state => state.comments)
-  const textareaRef = React.useRef()
+  const textareaRef = useRef()
 
   useEffect(() => {
     autogrow()
   }, [])
 
   const getSavePayload = () => {
-    return { text: textareaRef.current.value }
+    return {
+      text: textareaRef.current.value,
+    }
   }
 
   const forceUpdate = useForceUpdate()

--- a/app/javascript/components/Floater.js
+++ b/app/javascript/components/Floater.js
@@ -19,7 +19,7 @@ export function Floater(props) {
 
       if (!selection || selection.empty || mathNodeIsSelected) {
         return {
-          left: -1000,
+          left: -2000,
           top: 0,
         }
       }

--- a/app/javascript/components/editor-config/comments.js
+++ b/app/javascript/components/editor-config/comments.js
@@ -5,7 +5,7 @@ import { CommentForm } from '../CommentForm'
 import { store } from '../../store'
 
 import ReactDOM from 'react-dom'
-import React from 'react'
+import React, { useState } from 'react'
 import { saRequest } from '../../utils/saRequest'
 import classnames from 'classnames'
 
@@ -297,13 +297,13 @@ function buildUser() {
   return {
     id: currentUser.currentUser.id || '',
     avatar: currentUser.currentUser.attributes.avatar_url,
-    name: currentUser.currentUser.attributes.full_name,
+    username: currentUser.currentUser.attributes.username,
   }
 }
 
 function ThreadedComment(props) {
   const { comment, dispatch, state, className, showActions } = props
-  const [isShowingReply, setIsShowingReply] = React.useState(false)
+  const [isShowingReply, setIsShowingReply] = useState(false)
 
   const handleDelete = () => {
     dispatch(
@@ -342,17 +342,17 @@ function ThreadedComment(props) {
     >
       {comment.user && (
         <div className="j-commentUser">
-          <img
-            className="avatar"
-            src={comment.user.avatar}
-            alt={comment.user.name}
-          />
           <a
-            className="name"
+            className="name-card"
             href={comment.user.username ? '/@' + comment.user.username : '#'}
             target="blank"
           >
-            {comment.user.name}
+            <img
+              className="avatar"
+              src={comment.user.avatar}
+              alt={comment.user.username}
+            />
+            {comment.user.username}
           </a>
         </div>
       )}


### PR DESCRIPTION
addresses two bugs in [make editor gooder](https://github.com/jellypbc/poster/issues/318) https://github.com/jellypbc/poster/issues/318
- [x] move menubar off screen when no text selected
- [x] display username instead of full_name in threaded comment
- [x] link user avatar to user profile in threaded comment

menubar before:
![Beyond being there | Jelly 2020-10-26 16-10-14](https://user-images.githubusercontent.com/1177031/97248550-22282b80-17a6-11eb-8dbe-670b8d49a4ee.png)

menubar after:
![Beyond being there | Jelly 2020-10-26 16-10-33](https://user-images.githubusercontent.com/1177031/97248566-294f3980-17a6-11eb-856e-d84371a50402.png)

threaded comment before:
![before](https://user-images.githubusercontent.com/1177031/97248595-38ce8280-17a6-11eb-80ee-c16c14fcf92b.gif)

threaded comment after:
![afterafter](https://user-images.githubusercontent.com/1177031/97248774-9367de80-17a6-11eb-8d67-6e2541d1fee6.gif)
