### PR TITLE
Fix sidebar blockquote styles

### DIFF
--- a/app/assets/stylesheets/editor/sidebar.scss
+++ b/app/assets/stylesheets/editor/sidebar.scss
@@ -68,6 +68,10 @@
       padding-left: 4px;
       margin-bottom: 4px;
     }
+    blockquote {
+      padding-left: .2em;
+      border-left: 1px solid #eee;
+    }
     .math-block {
       font-size: 2px;
     }


### PR DESCRIPTION
This PR decreases padding on blockquote styles in sidebar.

before:

![Beyond being there | Jelly 2020-10-26 17-57-23](https://user-images.githubusercontent.com/1177031/97255479-d03ad200-17b4-11eb-8dae-0ab8e7a456e5.png)


after:

![Beyond being there | Jelly 2020-10-26 17-57-08](https://user-images.githubusercontent.com/1177031/97255483-d3ce5900-17b4-11eb-8143-ded7aec55ac2.png)
