### PR TITLE
Adds Log to homepage

### DIFF
--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -20,4 +20,6 @@
               = " | "
               = link_to 'GitHub', "https://github.com/jellypbc", target: '_blank'
               = " | "
+              = link_to 'Log', "https://soundcloud.com/user-262032969", target: '_blank'
+              = " | "
               = mail_to "aloha@jellypbc.com", "Email"


### PR DESCRIPTION
This PR adds `Log` to the homepage linking to our SoundCloud weekly audio updates.

![Kapture 2020-10-27 at 08 46 33](https://user-images.githubusercontent.com/1177031/97347612-22b9d400-1831-11eb-8d3c-dbe79a32fda0.gif)
