### PR TITLE
Preserves citation position to highlighted text

### DIFF
--- a/app/controllers/citations_controller.rb
+++ b/app/controllers/citations_controller.rb
@@ -1,7 +1,7 @@
 class CitationsController < ApplicationController
   before_action :set_citation, only: [:show, :edit, :update, :delete]
 
-  def add_citation
+  def create
     citation = Citation.new(citation_params)
 
     respond_to do |format|
@@ -13,8 +13,21 @@ class CitationsController < ApplicationController
     end
   end
 
+  def update 
+    respond_to do |format|
+      if @citation.update(citation_params)
+        format.html { redirect_to @citation, notice: 'Citation was successfully updated.'}
+        format.json { render :show, status: :ok, location: @citation }
+      else 
+        format.html { render :edit}
+        format.json { render json: @citation.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
   def delete
     @citation.delete_now if citation_params["deleted_at"]
+
     respond_to do |format|
       if @citation.save
         format.html { head :ok }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -45,6 +45,7 @@ class PostsController < ApplicationController
     respond_to do |format|
       if @post.update!(post_params)
         update_comments(@post) if params[:comments]
+        update_citations(@post) if params[:citations]
 
         serialized_post = PostSerializer.new(@post).as_json
 
@@ -149,6 +150,24 @@ class PostsController < ApplicationController
             text: comment_data["text"],
             data_from: comment_data["from"],
             data_to: comment_data["to"]
+          )
+        end
+      end
+    end
+
+    def update_citations(post)
+      if citations_data = JSON.parse(params['citations'])
+        citations_data.each do |citation_data|
+          citation = Citation.find_or_create_by(
+            data_key: citation_data["id"].to_s,
+            post_id: post.id
+          )
+
+          citation.update(
+            title: citation_data["text"],
+            data_from: citation_data["from"],
+            data_to: citation_data["to"],
+            highlighted_text: citation_data["highlightedText"]
           )
         end
       end

--- a/app/javascript/components/Editor.js
+++ b/app/javascript/components/Editor.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { EditorState } from 'prosemirror-state'
 import { EditorView } from 'prosemirror-view'
 import { commentPluginKey } from './editor-config/comments'
+import { citationPluginKey } from './editor-config/citations'
 // import applyDevTools from 'prosemirror-dev-tools'
 
 export class Editor extends React.Component {
@@ -23,6 +24,7 @@ export class Editor extends React.Component {
       }),
       dispatchTransaction: (transaction) => {
         const oldComments = commentPluginKey.getState(this.view.state)
+        const oldCitations = citationPluginKey.getState(this.view.state)
 
         const { state, transactions } = this.view.state.applyTransaction(
           transaction
@@ -31,10 +33,12 @@ export class Editor extends React.Component {
         this.view.updateState(state)
 
         const newComments = commentPluginKey.getState(state)
+        const newCitations = citationPluginKey.getState(state)
 
         if (
           transactions.some((tr) => tr.docChanged) ||
-          newComments !== oldComments
+          newComments !== oldComments ||
+          newCitations !== oldCitations
         ) {
           this.props.onChange(state.doc, state, props.field)
         }

--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -139,9 +139,12 @@ export function PostEditor(props) {
     const comments = JSON.stringify(
       commentPluginKey.getState(docState).allComments()
     )
-    const citations = JSON.stringify(
-      citationPluginKey.getState(docState).allCitations()
-    )
+
+    const citations =
+      field !== 'title'
+        ? JSON.stringify(citationPluginKey.getState(docState).allCitations())
+        : ''
+
     const url = isNewPost ? '/posts' : post.data.attributes.form_url
     const method = isNewPost ? 'post' : 'put'
 

--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -23,6 +23,7 @@ import {
 } from './editor-config/index'
 
 import { commentPluginKey } from './editor-config/comments'
+import { citationPluginKey } from './editor-config/citations'
 
 import {
   getTimestamp,
@@ -138,13 +139,16 @@ export function PostEditor(props) {
     const comments = JSON.stringify(
       commentPluginKey.getState(docState).allComments()
     )
+    const citations = JSON.stringify(
+      citationPluginKey.getState(docState).allCitations()
+    )
     const url = isNewPost ? '/posts' : post.data.attributes.form_url
     const method = isNewPost ? 'post' : 'put'
 
     const data =
       field === 'title'
         ? { title: doc, comments: comments }
-        : { body: doc, comments: comments }
+        : { body: doc, comments: comments, citations: citations }
 
     submit(data, method, url, onSuccess)
   }

--- a/app/javascript/components/editor-config/citations.js
+++ b/app/javascript/components/editor-config/citations.js
@@ -36,6 +36,25 @@ class CitationState {
       if (current[i].type.spec.id == id) return current[i]
   }
 
+  citationsAt(pos) {
+    return this.decos.find(pos, pos)
+  }
+
+  allCitations() {
+    let { decos } = this
+    const citations = decos.find().map((citation) => {
+      console.log('citation', citation.type.spec.id)
+      return {
+        to: citation.to,
+        from: citation.from,
+        id: citation.type.spec.id,
+        text: citation.type.spec.title,
+        highlightedText: citation.type.spec.highlightedText,
+      }
+    })
+    return citations
+  }
+
   apply(tr) {
     let action = tr.getMeta(citationPlugin),
       actionType = action && action.type
@@ -43,7 +62,7 @@ class CitationState {
     let base = this
     let { decos } = base
     decos = decos.map(tr.mapping, tr.doc)
-    console.log('action', action)
+
     if (actionType == 'newCitation') {
       decos = decos.add(tr.doc, [deco(action.from, action.to, action.citation)])
       submitCitationCreate(action)
@@ -55,25 +74,13 @@ class CitationState {
   }
 
   static init(config) {
-    const citations = config.doc.citations
+    const existingCitations = config.doc.citations.citations || []
 
-    if (citations) {
-      let decos = citations.citations.map((p) =>
-        deco(
-          p.from,
-          p.to,
-          new Citation(p.id, p.title, p.highlightedText, p.url)
-        )
-      )
-      const d = DecorationSet.create(config.doc, decos)
-      return new CitationState(d)
-    } else {
-      return new CitationState(DecorationSet.create(config.doc, []))
-    }
-  }
+    let decos = existingCitations.map((c) =>
+      deco(c.from, c.to, new Citation(c.id, c.title, c.highlightedText, c.url))
+    )
 
-  citationsAt(pos) {
-    return this.decos.find(pos, pos)
+    return new CitationState(DecorationSet.create(config.doc, decos))
   }
 }
 

--- a/app/javascript/components/editor-config/citations.js
+++ b/app/javascript/components/editor-config/citations.js
@@ -43,7 +43,6 @@ class CitationState {
   allCitations() {
     let { decos } = this
     const citations = decos.find().map((citation) => {
-      console.log('citation', citation.type.spec.id)
       return {
         to: citation.to,
         from: citation.from,

--- a/app/javascript/components/editor-config/images.js
+++ b/app/javascript/components/editor-config/images.js
@@ -1,4 +1,4 @@
-import { store, images, waitForStore, TIMEOUT_ERROR } from '../../store'
+import { store, images, waitForStore } from '../../store'
 import { schema } from './schema'
 
 // note: "pm" = ProseMirror, "store" = app-wide redux store

--- a/app/javascript/components/editor-config/keys.js
+++ b/app/javascript/components/editor-config/keys.js
@@ -23,6 +23,7 @@ import {
 
 import { schema } from './schema'
 import { addAnnotation } from './comments'
+import { addCitation } from './citations'
 import menu from './menu'
 
 const insertBreak = (state, dispatch) => {
@@ -69,6 +70,7 @@ const keys = {
   Tab: goToNextCell(1),
   'Shift-Tab': goToNextCell(-1),
   'Mod-Shift-m': addAnnotation,
+  'Mod-Shift-l': addCitation,
 }
 
 Object.keys(baseKeymap).forEach((key) => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
   post '/remove_comment', to: 'comments#delete', as: :remove_comment
 
   resources :citations
-  post '/add_citation', to: 'citations#add_citation', as: :add_citation
+  post '/add_citation', to: 'citations#create', as: :add_citation
   post '/remove_citation', to: 'citations#delete', as: :remove_citation
 
   namespace :search do


### PR DESCRIPTION
This PR updates the `data_from` and `data_to` position of citations when a document changes, so the citations stay attached to theirl highlighted text.

Fixes https://github.com/jellypbc/poster/issues/233

Note: The title editor does not allow citations, so no citations are sent as data when saving the title editor.

after:
![Kapture 2020-11-19 at 17 44 12](https://user-images.githubusercontent.com/1177031/99755578-36063b00-2a8f-11eb-94fe-ecaedc046fbb.gif)


before:
![Kapture 2020-11-19 at 17 46 24](https://user-images.githubusercontent.com/1177031/99755600-44545700-2a8f-11eb-8b94-847eed3875f2.gif)

