### PR TITLE
Fixes paginated_citations method and corrects post count in PostContainer tabs

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -104,7 +104,7 @@ class TagsController < ApplicationController
           .map{ |c| c.generated_post_id}
           .uniq
 
-        @generated_posts = Post.where(id: @citation_array)
+        @generated_posts = Post.where(id: citation_array)
           .order(created_at: :desc)
           .paginate(page: params[:citations_page], per_page: 10)
 

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -7,4 +7,5 @@
       span.mr-3.ml-3 © 2020 Jelly PBC
       = link_to "About", about_path, class: "mr-3 ml-3"
       = link_to "Terms", terms_path, class: "mr-3 ml-3"
-      = link_to "Blog", "https://jellypbc.com", class: "mr-3 ml-3"
+      = link_to 'Blog', blog_path, class: "mr-3 ml-3"
+

--- a/app/views/tags/show.html.slim
+++ b/app/views/tags/show.html.slim
@@ -11,5 +11,5 @@
           #posts.tab-pane.fade.show.active role="tabpanel" aria-labelledby="posts-tab"
             = react_component "PostsContainer",
               tag: @tag,
-              postsCount: @posts.size,
-              citationsCount: @generated_posts.size
+              postsCount: @posts.count,
+              citationsCount: @generated_posts.count

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -32,6 +32,6 @@
           #posts.tab-pane.fade.show.active role="tabpanel" aria-labelledby="posts-tab"
             = react_component "PostsContainer",
               user: @user,
-              postsCount: @primary_posts.size,
-              citationsCount: @generated_posts.size
+              postsCount: @primary_posts.count,
+              citationsCount: @generated_posts.count
 


### PR DESCRIPTION
This PR fixes two bugs introduced in https://github.com/jellypbc/poster/pull/343.

1. citations tab on collection page showing no posts when posts exist
2. PostContainer tabs showing count of 10 posts when total posts > 10

- [x] fixes `paginate_citations` method to return citation posts
- [x] fixes `PostContainer` tabs to show accurate post count 
- [x] updates footer Blog path

after:
![Kapture 2020-11-22 at 15 07 16](https://user-images.githubusercontent.com/1177031/99922590-6fc88300-2cd5-11eb-983b-36dfc4a37e41.gif)

before:
![beforebefore](https://user-images.githubusercontent.com/1177031/99922616-8b338e00-2cd5-11eb-96d2-1646c9d402b3.gif)
