### PR TITLE
Fixes removing tag from post in TagForm

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_tree ../images
 //= link application.js
 //= link application.css
+//= link_directory ../javascripts .js

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -63,6 +63,25 @@ class TagsController < ApplicationController
     end
   end
 
+  def delete
+    if tag_params["deleted_at"]
+      @tag = Tag.find_by_id(tag_params[:id])
+      @post = Post.find_by_id(tag_params[:post_id])
+
+      @post.tags.delete(@tag)
+
+      respond_to do |format|
+        if @post.save
+          format.html { head :ok }
+          format.json { render json: {post: @post }, status: :ok }
+        else 
+          format.html { head :ok }
+          format.json { render json: @post.errors, status: :unprocessable_entity}
+        end
+      end
+    end
+  end
+
   def paginated_posts
     @tag = Tag.find params[:id]
     
@@ -144,7 +163,7 @@ class TagsController < ApplicationController
 
     def tag_params
       params.require(:tag).permit(
-        :id, :text, :slug, :post_id, :user_id
+        :id, :text, :slug, :post_id, :user_id, :deleted_at
       )
     end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -68,10 +68,10 @@ class TagsController < ApplicationController
       @tag = Tag.find_by_id(tag_params[:id])
       @post = Post.find_by_id(tag_params[:post_id])
 
-      @post.tags.delete(@tag)
+      
 
       respond_to do |format|
-        if @post.save
+        if @post.tags.delete(@tag) && @post.save
           format.html { head :ok }
           format.json { render json: {post: @post }, status: :ok }
         else 

--- a/app/javascript/components/TagForm.js
+++ b/app/javascript/components/TagForm.js
@@ -20,6 +20,7 @@ export default function TagForm({ post, suggestedTags, currentUser }) {
         }
       })
   }
+
   const handleDelete = (i) => {
     const tagToDelete = tags.find((tag, index) => index === i)
     sendRequest(tagToDelete, 'delete').then((res) => {
@@ -42,7 +43,7 @@ export default function TagForm({ post, suggestedTags, currentUser }) {
   }
 
   async function sendRequest(tag, action) {
-    var data = {
+    let data = {
       tag: {
         user_id: currentUser.id,
         text: tag.text,
@@ -51,18 +52,18 @@ export default function TagForm({ post, suggestedTags, currentUser }) {
       },
     }
 
-    let url, method
+    let url
     if (action === 'add') {
-      url = post.data.attributes.form_url + '/tags'
-      method = 'post'
+      url = '/add_tag'
     } else {
       data.tag.id = tag.id
-      url = post.data.attributes.form_url + '/tags/' + tag.id
-      method = 'delete'
+      data.tag.deleted_at = true
+      url = '/remove_tag'
     }
 
     return new Promise((resolve, reject) => {
-      saRequest[method](url)
+      saRequest
+        .post(url)
         .send(data)
         .set('accept', 'application/json')
         .then((res) => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,8 @@ Rails.application.routes.draw do
   end
 
   resources :tags
+  post '/add_tag', to: 'tags#create', as: :add_tag
+  post '/remove_tag', to: 'tags#delete', as: :remove_tag
 
   resources :comments
   post '/add_comment', to: 'comments#create', as: :add_comment
@@ -78,12 +80,6 @@ Rails.application.routes.draw do
   get '/internship', to: 'pages#jobs'
 
   get '/blog', to: redirect('tags/jelly-blog')
-
-  get 'users/:id/paginated_posts/:page', to: 'users#paginated_posts'
-  get 'users/:id/paginated_citations/:page', to: 'users#paginated_citations'
-
-  get 'tags/:id/paginated_posts/:page', to: 'tags#paginated_posts'
-  get 'tags/:id/paginated_citations/:page', to: 'tags#paginated_citations'
 
   get 'users/:id/paginated_posts/:page', to: 'users#paginated_posts'
   get 'users/:id/paginated_citations/:page', to: 'users#paginated_citations'


### PR DESCRIPTION
This PR updates `TagForm` `handleDelete` to remove the selected tag from the post instead of destroying the tag. 

Fixes the following bug:

- removing a tag from post results in destroying the tag 😅

after:
Deleting a tag from a post removes tag from post.
![afterafter](https://user-images.githubusercontent.com/1177031/99925281-9e4c5b00-2ce1-11eb-97cb-9b0f7da8a0e7.gif)

before:
Deleting a tag from a post destroys the tag.
![beforebeforebefore](https://user-images.githubusercontent.com/1177031/99925286-a60bff80-2ce1-11eb-845a-27b19c0d101d.gif)
