### PR TITLE
Removes footnotes plugin

### DIFF
--- a/app/javascript/components/editor-config/icons.js
+++ b/app/javascript/components/editor-config/icons.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-  faAsterisk,
   faBold,
   faItalic,
   faCode,
@@ -43,7 +42,6 @@ export default {
   bullet_list: <FontAwesomeIcon icon={faListUl} />,
   image: <FontAwesomeIcon icon={faImage} />,
   table: <FontAwesomeIcon icon={faTable} />,
-  footnote: <FontAwesomeIcon icon={faAsterisk} />,
   undo: <FontAwesomeIcon icon={faUndo} />,
   redo: <FontAwesomeIcon icon={faRedo} />,
   lift: <FontAwesomeIcon icon={faOutdent} />,

--- a/app/javascript/components/editor-config/menu.js
+++ b/app/javascript/components/editor-config/menu.js
@@ -219,15 +219,6 @@ export default {
     //     dispatch(state.tr.replaceSelectionWith(img))
     //   },
     // },
-    footnote: {
-      title: 'Insert footnote',
-      content: icons.footnote,
-      enable: canInsert(schema.nodes.footnote),
-      run: (state, dispatch) => {
-        const footnote = schema.nodes.footnote.create()
-        dispatch(state.tr.replaceSelectionWith(footnote))
-      },
-    },
     // hr: {
     //   title: 'Insert horizontal rule',
     //   content: 'HR',

--- a/app/javascript/components/editor-config/nodes.js
+++ b/app/javascript/components/editor-config/nodes.js
@@ -1,6 +1,5 @@
 import { orderedList, bulletList, listItem } from './schema-list'
 import { tableNodes } from 'prosemirror-tables'
-import { footnoteNodes } from '@aeaton/prosemirror-footnotes'
 
 const pDOM = ['p', 0],
   blockquoteDOM = ['blockquote', 0],
@@ -171,5 +170,4 @@ export default {
     tableGroup: 'block',
     cellContent: 'block+',
   }),
-  ...footnoteNodes,
 }

--- a/app/javascript/components/editor-config/plugins.js
+++ b/app/javascript/components/editor-config/plugins.js
@@ -8,12 +8,8 @@ import { citationPlugin, citationUI } from './citations'
 import { math } from './math'
 import { placeholder } from './placeholder'
 
-// TODO: move directly into components
-import { footnotes } from '@aeaton/prosemirror-footnotes'
-
 // import 'prosemirror-tables/style/tables.css'
 import 'prosemirror-gapcursor/style/gapcursor.css'
-import '@aeaton/prosemirror-footnotes/style/footnotes.css'
 
 import { bodyEditorKeys, titleEditorKeys } from './keys'
 import rules from './rules'
@@ -24,7 +20,6 @@ export const bodyPlugins = (getView) => [
   rules,
   bodyEditorKeys,
   placeholder(),
-  footnotes(),
   dropCursor(),
   gapCursor(),
   history(),

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "node": "14.x"
   },
   "dependencies": {
-    "@aeaton/prosemirror-footnotes": "^0.1.0",
     "@aeaton/prosemirror-placeholder": "^0.1.0",
     "@babel/core": "^7.7.2",
     "@babel/plugin-proposal-class-properties": "^7.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,6 @@
 # yarn lockfile v1
 
 
-"@aeaton/prosemirror-footnotes@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@aeaton/prosemirror-footnotes/-/prosemirror-footnotes-0.1.0.tgz#fa96079dd4b8a3218769aaa0ad6826e1d0380653"
-  integrity sha1-+pYHndS4oyGHaaqgrWgm4dA4BlM=
-  dependencies:
-    prosemirror-history "^1.0.0"
-    prosemirror-keymap "^1.0.0"
-    prosemirror-state "^1.1.0"
-    prosemirror-transform "^1.0.0"
-    prosemirror-view "^1.1.1"
-
 "@aeaton/prosemirror-placeholder@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@aeaton/prosemirror-placeholder/-/prosemirror-placeholder-0.1.0.tgz#1c4a56d6edba5ecff519d7abfdaca06be4c88290"
@@ -3412,12 +3401,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001038, caniuse-lite@^1.0.30001039:
-  version "1.0.30001151"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001151.tgz"
-  integrity sha512-Zh3sHqskX6mHNrqUerh+fkf0N72cMxrmflzje/JyVImfpknscMnkeJrlFGJcqTmaa0iszdYptGpWMJCRQDkBVw==
-
-caniuse-lite@^1.0.30001111:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001038, caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001111:
   version "1.0.30001151"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001151.tgz"
   integrity sha512-Zh3sHqskX6mHNrqUerh+fkf0N72cMxrmflzje/JyVImfpknscMnkeJrlFGJcqTmaa0iszdYptGpWMJCRQDkBVw==


### PR DESCRIPTION
This PR removes footnotes plugin. The footnote UX provided by [@aeaton/prosemirror-footnotes](https://www.npmjs.com/package/@aeaton/prosemirror-footnotes) is not our desired footnote UX for Jelly.

For now, users can add footnotes by making text superscript and adding an inline comment. 

We may revisit footnotes in the future.