### PR TITLE
Set up canonical host redirect

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,8 @@
+GCS_BUCKET=jellyposter-store
+STORAGE_PROJECT='jellyposter'
+GOOGLE_CLOUD_PROJECT='jellyposter'
+GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS='true'
+
+# comment these out if using docker
+GROBID_HOST=localhost
+FIGURE_HOST=localhost

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -1,5 +1,7 @@
 # This is a sample configuration file
 
+CANONICAL_HOST=
+
 DB_POOL=
 RAILS_MAX_THREADS=
 DB_NAME=

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -11,6 +11,7 @@ Just the hostname, e.g. jellypbc.com
 ```
 HOSTNAME=
 ```
+If you want to force redirects to root domain, then you can set `CANONICAL_HOST=` as well.
 
 2. Shrine storage
 Defaults to using Google Cloud Storage, assuming you have buckets created with your hostname, e.g. jellyposter-cache, jellyposter-store.  Set in your environment variables:

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 gem "searchkick"
 gem "typhoeus"
 gem "oj"
+gem "rack-canonical-host"
 
 group :development, :test do
   gem "rspec-rails", '~> 4.0'
@@ -54,7 +55,6 @@ group :development, :test do
   gem "pry"
   gem "pry-rails"
   gem "docker-sync", require: false
-  gem "cypress-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,9 +97,6 @@ GEM
     connection_pool (2.2.3)
     content_disposition (1.0.0)
     crass (1.0.6)
-    cypress-rails (0.3.0)
-      puma (>= 3.8.0)
-      railties (>= 5.2.0)
     daemons (1.3.1)
     debug_inspector (0.0.3)
     declarative (0.0.10)
@@ -342,6 +339,9 @@ GEM
     rack (2.2.3)
     rack-attack (6.3.1)
       rack (>= 1.0, < 3)
+    rack-canonical-host (1.0.0)
+      addressable (> 0, < 3)
+      rack (>= 1.0.0, < 3)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -559,7 +559,6 @@ DEPENDENCIES
   bundler (~> 2.1.4)
   byebug
   capybara (>= 2.15)
-  cypress-rails
   devise
   devise-guests
   docker-sync
@@ -588,6 +587,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rack-attack
+  rack-canonical-host
   rack-timeout
   rails (~> 6.0.3)
   rails-controller-testing

--- a/config.ru
+++ b/config.ru
@@ -2,4 +2,8 @@
 
 require_relative 'config/environment'
 
+if ENV['CANONICAL_HOST']
+  use Rack::CanonicalHost, ENV['CANONICAL_HOST']
+end
+
 run Rails.application


### PR DESCRIPTION
Adds rack-canonical-host for root domain redirect. Also updates the documentation for this option.