### PR TITLE
Sorts collections by alphabetical order

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -11,7 +11,7 @@ class PagesController < ApplicationController
         .order(created_at: :desc)
         .paginate(page: params[:page], per_page: 10)
 
-      @tags = current_user.tags
+      @tags = current_user.tags.sort_by { |tag| tag.slug}
 
       render 'dashboard'
     end

--- a/app/views/devise/shared/_links.html.slim
+++ b/app/views/devise/shared/_links.html.slim
@@ -1,6 +1,6 @@
 p.devise__sharedLinks
   - if devise_mapping.confirmable? && controller_name != 'confirmations' && controller_name != 'registrations' && controller_name != 'passwords'
-    = link_to "Resend Confirmation", new_confirmation_path(resource_name)
+    = link_to "Resend Confirmation", new_user_confirmation_path(resource_name)
 
   - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' && controller_name != 'registrations' && controller_name != 'passwords'
     = link_to "Resend Unlock", new_unlock_path(resource_name)


### PR DESCRIPTION
This PR sorts collections in alphabetical order and fixes invalid path used by devise. 
after:
![Jelly 2020-11-23 16-13-42](https://user-images.githubusercontent.com/1177031/100037805-f6996080-2da6-11eb-9ada-cb17dd6f7482.png)


before:
![Jelly 2020-11-23 16-13-55](https://user-images.githubusercontent.com/1177031/100037816-fa2ce780-2da6-11eb-9906-97e65b84fe41.png)
