### PR TITLE
Fixes copy pasting into jelly from external sources and markdown editors

### DIFF
--- a/app/assets/stylesheets/editor/defaults.scss
+++ b/app/assets/stylesheets/editor/defaults.scss
@@ -47,13 +47,13 @@
 }
 
 .ProseMirror ul, .ProseMirror ol {
-  padding-left: 30px;
+  padding-left: 2em;
 }
 
 .ProseMirror blockquote {
   padding-left: 1em;
   border-left: 3px solid #eee;
-  margin-left: 0;
+  margin-left: 1em;
   margin-right: 0;
 }
 
@@ -72,7 +72,17 @@
   line-height: 0;
 }
 
+.post-editor .ProseMirror > p {
+  padding-bottom: 1em;
+}
 
+.ProseMirror p.empty-node {
+  padding-bottom: 0;
+}
+
+.ProseMirror h2, h3, h4 {
+  padding-bottom: 1em;
+}
 
 // prosemirror-view/style/prosemirror
 // https://github.com/ProseMirror/prosemirror-view/blob/master/style/prosemirror.css
@@ -92,6 +102,8 @@
 
 .ProseMirror pre {
   white-space: pre-wrap;
+  margin-left: 1em;
+  border-radius: 0px;
 }
 
 .ProseMirror li {

--- a/app/views/devise/shared/_links.html.slim
+++ b/app/views/devise/shared/_links.html.slim
@@ -1,6 +1,6 @@
 p.devise__sharedLinks
   - if devise_mapping.confirmable? && controller_name != 'confirmations' && controller_name != 'registrations' && controller_name != 'passwords'
-    = link_to "Resend Confirmation", new_confirmation_path(resource_name)
+    = link_to "Resend Confirmation", new_user_confirmation_path(resource_name)
 
   - if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' && controller_name != 'registrations' && controller_name != 'passwords'
     = link_to "Resend Unlock", new_unlock_path(resource_name)


### PR DESCRIPTION
This PR adds padding below paragraph and heading nodes (ignores paragraph nodes in ul and ol and ignores empty paragraph nodes). Blockquote, code block, ul, ol use margin left of `2em`. 

User can copy from standard web page or external editors and paste content into Jelly resulting in expected copy paste behavior. Copy paste tested with Medium, Tumblr, Typora, The New York Times, PLOS.

Note: Copy and paste from Word and Google Docs is out of the scope of this PR. Copy and paste equations from PLOS to Jelly is also out of scope.

copy and paste demo:
![Kapture 2020-11-23 at 18 16 59](https://user-images.githubusercontent.com/1177031/100048111-1dac5e00-2db8-11eb-8c10-1147ee6cb79e.gif)

after:
![Paper Title | Jelly 2020-11-23 17-59-57](https://user-images.githubusercontent.com/1177031/100047623-facd7a00-2db6-11eb-8aa8-2315433d97cf.png)

before:
![Paper Title | Jelly 2020-11-23 18-02-43](https://user-images.githubusercontent.com/1177031/100047633-015bf180-2db7-11eb-9614-ae90ed32eef5.png)



