### PR TITLE
Matches nav bar and post page fallback styles to react component styles

### DIFF
--- a/app/assets/stylesheets/editor/defaults.scss
+++ b/app/assets/stylesheets/editor/defaults.scss
@@ -76,12 +76,24 @@
   padding-bottom: 1em;
 }
 
-.ProseMirror p.empty-node {
+.post-editor > p {
+  padding-bottom: 1em;
+}
+
+.post-editor .ProseMirror p.empty-node {
   padding-bottom: 0;
 }
 
-.ProseMirror h2, h3, h4 {
+.post-editor .ProseMirror h2, h3, h4 {
   padding-bottom: 1em;
+}
+
+.post-editor h2, h3, h4 {
+  padding-bottom: 1em;
+}
+
+.post-editor .ProseMirror blockquote {
+  margin-bottom: 1em
 }
 
 // prosemirror-view/style/prosemirror

--- a/app/views/shared/_nav.html.slim
+++ b/app/views/shared/_nav.html.slim
@@ -16,8 +16,8 @@ nav.navbar.navbar-expand-lg id="#{opts[:id] if opts}" class="#{'white-nav' if wh
     #menu.collapse.navbar-collapse
       = react_component 'SearchBar'
 
-      = form_tag(search_results_path, method: :get, id: 'search-fallback', class: "form-inline my-2 my-lg-0")
-        = text_field_tag :query, nil, placeholder: "Search", type: "search", 'aria-label'=>'Search'
+      = form_tag(search_results_path, method: :get, id: 'search-fallback', class: "my-2 my-lg-0")
+        = text_field_tag :query, nil, placeholder: "Search", type: "search", 'aria-label'=>'Search', class: "form-control"
 
       ul.subnav.ml-auto
         - if current_user


### PR DESCRIPTION
This PR updates the styles for the fallback of search in nav bar and post content in editor. Prior to this PR the fallback styles did not match the styles of react components producing a clunky user experience when loading the page. 

- [x] add 1em padding-bottom for `p` without `.Prosemirror`
- [x] add 1em padding-bottom `h2`, `h3`, `h4` without `.Prosemirror`
- [x] add 1em padding below `blockquote`
- [x] fix `search-fallback` styles to match react component for search in nav

before:
left = fallback, right = react components rendered
![before_fallback](https://user-images.githubusercontent.com/1177031/100565383-92bfdd80-3267-11eb-8cbc-70b7f9632dc6.png)


after: 
left = fallback, right = react components rendered
![fallback_after](https://user-images.githubusercontent.com/1177031/100565417-aa976180-3267-11eb-9ceb-61f1aa46054c.png)
