### PR TITLE
Adds outline to sidebar

### DIFF
--- a/app/assets/stylesheets/editor/defaults.scss
+++ b/app/assets/stylesheets/editor/defaults.scss
@@ -55,6 +55,7 @@
   border-left: 3px solid #eee;
   margin-left: 1em;
   margin-right: 0;
+  margin-bottom: 1em;
 }
 
 .ProseMirror img {
@@ -72,27 +73,29 @@
   line-height: 0;
 }
 
-.post-editor .ProseMirror > p {
+.ProseMirror > p {
   padding-bottom: 1em;
 }
 
-.post-editor .ProseMirror p.empty-node {
+.ProseMirror p.empty-node {
   padding-bottom: 0;
 }
 
-.post-editor .ProseMirror h2, h3, h4 {
+.ProseMirror h2, h3, h4 {
   padding-bottom: 1em;
 }
-
-.post-editor h2, h3, h4 {
-  padding-bottom: 1em;
+.ProseMirror pre {
+  margin-left: 1em;
+  border-radius: 0px;
 }
 
-.post-editor .ProseMirror blockquote {
-  margin-bottom: 1em
+.selection-marker {
+  font-family: inherit;
+  font-size: inherit;
 }
 
-// prosemirror-view/style/prosemirror
+// do not edit css below
+// prosemirror-view/blob/style/prosemirror
 // https://github.com/ProseMirror/prosemirror-view/blob/master/style/prosemirror.css
 
 .ProseMirror {
@@ -110,8 +113,6 @@
 
 .ProseMirror pre {
   white-space: pre-wrap;
-  margin-left: 1em;
-  border-radius: 0px;
 }
 
 .ProseMirror li {
@@ -127,10 +128,6 @@
 }
 
 /* Make sure li selections wrap around markers */
-.selection-marker {
-  font-family: inherit;
-  font-size: inherit;
-}
 
 li.ProseMirror-selectednode {
   outline: none;

--- a/app/assets/stylesheets/editor/defaults.scss
+++ b/app/assets/stylesheets/editor/defaults.scss
@@ -90,7 +90,13 @@
   line-height: 0;
 }
 
+.ProseMirror span.underline {
+  text-decoration: underline;
+}
 
+.ProseMirror span.strikethrough {
+  text-decoration-line: line-through;
+}
 
 .selection-marker {
   font-family: inherit;

--- a/app/assets/stylesheets/editor/defaults.scss
+++ b/app/assets/stylesheets/editor/defaults.scss
@@ -4,7 +4,6 @@
     min-width: 640px;
     margin: 0;
     padding: 0;
-
   }
 }
 
@@ -26,6 +25,27 @@
 .ProseMirror {
   font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   background: #fff;
+}
+
+.ProseMirror h2, h3, h4 {
+  padding-bottom: 1em;
+}
+
+.ProseMirror > p {
+  padding-bottom: 1em;
+}
+
+.ProseMirror p.empty-node {
+  padding-bottom: 0;
+}
+
+.ProseMirror img {
+  cursor: default;
+}
+
+.ProseMirror pre {
+  margin-left: 1em;
+  border-radius: 0px;
 }
 
 .ProseMirror:focus {
@@ -58,9 +78,6 @@
   margin-bottom: 1em;
 }
 
-.ProseMirror img {
-  cursor: default;
-}
 
 .ProseMirror th,
 .ProseMirror td {
@@ -73,21 +90,7 @@
   line-height: 0;
 }
 
-.ProseMirror > p {
-  padding-bottom: 1em;
-}
 
-.ProseMirror p.empty-node {
-  padding-bottom: 0;
-}
-
-.ProseMirror h2, h3, h4 {
-  padding-bottom: 1em;
-}
-.ProseMirror pre {
-  margin-left: 1em;
-  border-radius: 0px;
-}
 
 .selection-marker {
   font-family: inherit;
@@ -113,6 +116,7 @@
 
 .ProseMirror pre {
   white-space: pre-wrap;
+  margin-bottom: 1em;
 }
 
 .ProseMirror li {

--- a/app/assets/stylesheets/editor/defaults.scss
+++ b/app/assets/stylesheets/editor/defaults.scss
@@ -76,10 +76,6 @@
   padding-bottom: 1em;
 }
 
-.post-editor > p {
-  padding-bottom: 1em;
-}
-
 .post-editor .ProseMirror p.empty-node {
   padding-bottom: 0;
 }

--- a/app/assets/stylesheets/editor/math.scss
+++ b/app/assets/stylesheets/editor/math.scss
@@ -7,7 +7,7 @@
   content: "( " counter(math-block) " )";
   padding-left: 100px;
   position: absolute;
-  right: 1rem;
+  right: 1em;
 }
 
 .math-block .katex-render {

--- a/app/assets/stylesheets/editor/sidebar.scss
+++ b/app/assets/stylesheets/editor/sidebar.scss
@@ -48,18 +48,28 @@
     }
     
     // editor body does not support h1
-    // TODO: separate out h2 = 4px, h3 = 3px, h4 = 2px
-    .ProseMirror h2, h3, h4 {
+    .ProseMirror h2 {
       font-size: 4px;
       line-height: 3px;
       letter-spacing: -0.1em;
-      padding-bottom: 1em;
+    }
+
+    .ProseMirror h3 {
+      font-size: 3px;
+      line-height: 3px;
+      letter-spacing: -0.1em;
+    }
+
+    .ProseMirror h4 {
+      font-size: 2px;
+      line-height: 3px;
+      letter-spacing: -0.1em;
     }
 
     .ProseMirror p, strong, li, a {
       font-size: 2px;
       line-height: 3px;
-      letter-spacing: .05em;
+      letter-spacing: -0.1em;
     }
     
     .ProseMirror a {

--- a/app/assets/stylesheets/editor/sidebar.scss
+++ b/app/assets/stylesheets/editor/sidebar.scss
@@ -128,29 +128,24 @@
   }
 
   #sidebarOutline {
-    margin-top: 1em;
-    color: blue;
-    h2 {
-      font-size: 8px;
-      line-height: 8px;
-      padding-bottom: 2em;
-      letter-spacing: -0.1em;
-    }
+    margin-top: 2em;
+    font-size: .5em;
+    line-height: 2em;
+    width: 190px;
+    cursor: pointer;
 
-    h3 {
-      font-size: 8px;
-      line-height: 9px;
+    .lv-1, .lv-2 {
+      padding-left: none;
       padding-bottom: 2em;
+    }
+    .lv-3 {
       padding-left: 2em;
-      letter-spacing: -0.1em;
+      padding-bottom: 2em;
     }
 
-    h4 {
-      font-size: 8px;
-      line-height: 8px;
+    .lv-4 {
       padding-bottom: 2em;
-      padding-left: 4em;
-      letter-spacing: -0.1em;
+      padding-bottom: 2em;
     }
 
   }

--- a/app/assets/stylesheets/editor/sidebar.scss
+++ b/app/assets/stylesheets/editor/sidebar.scss
@@ -107,6 +107,14 @@
     .ProseMirror-selectednode {
       outline: none;
     }
+
+    .ProseMirror span.underline {
+      text-decoration: none;
+    }
+
+    .ProseMirror span.strikethrough {
+      text-decoration-line: none;
+    }
   }
 }
 

--- a/app/assets/stylesheets/editor/sidebar.scss
+++ b/app/assets/stylesheets/editor/sidebar.scss
@@ -1,91 +1,3 @@
-@include media-breakpoint-down(md) {
-  #sidebar {
-    display: none;
-  }
-}
-
-#sidebarContainer {
-  @include desktop-styles {
-    display: block;
-  }
-  display: none;
-
-  a {
-    pointer-events: none;
-  }
-
-  #sidebarToggle {
-    color: $shaleLight;
-    transition: all 0.1s linear;
-
-    &.rotate {
-      -moz-transform:rotate(-90deg);
-      -webkit-transform:rotate(-90deg);
-      transform:rotate(-90deg);
-    }
-  }
-
-  .ProseMirror {
-    padding-left: 1px;
-    counter-reset: math-block;
-    user-select: none;
-    h1 {
-      font-size: 3px;
-      line-height: 4px;
-    }
-    h2, h3, h4 {
-      font-size: 3px;
-      line-height: 4px;
-      letter-spacing: -0.1em;
-    }
-    p, strong, li, a {
-      font-size: 2px;
-      line-height: 3px;
-    }
-    img {
-      max-height: 30px;
-      text-align: center;
-      margin: auto;
-    }
-    pre {
-      padding-left: 1px;
-      margin: 0;
-      border-radius: 1px;
-      line-height: 0;
-    }
-    code {
-      font-size: 2px;
-      line-height: 0;
-    }
-    li {
-      margin: 2px 0px;
-    }
-    ol {
-      padding-left: 4px;
-      margin-bottom: 4px;
-    }
-    ul {
-      padding-left: 4px;
-      margin-bottom: 4px;
-    }
-    blockquote {
-      padding-left: .2em;
-      border-left: 1px solid #eee;
-    }
-    .math-block {
-      font-size: 2px;
-    }
-    .math-block .katex-render::after {
-      counter-increment: math-block;
-      content: counter(math-block)
-    }
-  }
-  
-  .ProseMirror-selectednode {
-    outline: none;
-  }
-}
-
 @include media-breakpoint-down(xl) {
   #sidebarContainer {
     display: block;
@@ -106,3 +18,96 @@
     display: none;
   }
 }
+
+#sidebarContainer {
+  @include desktop-styles {
+    display: block;
+  }
+  display: none;
+
+  #sidebarToggle {
+    color: $shaleLight;
+    transition: all 0.1s linear;
+
+    &.rotate {
+      -moz-transform:rotate(-90deg);
+      -webkit-transform:rotate(-90deg);
+      transform:rotate(-90deg);
+    }
+  }
+
+  #sidebarEditor {
+
+    .ProseMirror {
+      padding-left: 1px;
+      padding-right: 1px;
+      counter-reset: math-block;
+      user-select: none;
+      padding-top: 2px;
+      // text-decoration: none;
+    }
+    
+    // editor body does not support h1
+    // TODO: separate out h2 = 4px, h3 = 3px, h4 = 2px
+    .ProseMirror h2, h3, h4 {
+      font-size: 4px;
+      line-height: 3px;
+      letter-spacing: -0.1em;
+      padding-bottom: 1em;
+    }
+
+    .ProseMirror p, strong, li, a {
+      font-size: 2px;
+      line-height: 3px;
+      letter-spacing: .05em;
+    }
+    
+    .ProseMirror a {
+      pointer-events: none;
+    }
+
+    .ProseMirror img {
+      // this should not be max-height
+       max-height: 80px;
+       margin: auto;
+    }
+
+    .ProseMirror pre {
+      font-size: 2px;
+      padding: .5em 1em;
+    }
+
+    .ProseMirror ul {
+      font-size: 2px;
+      padding-left: 4em;
+      margin-bottom: 1em;
+    }
+
+    .ProseMirror ol {
+      font-size: 2px;
+      padding-left: 2em;
+      margin-bottom: 1em;
+    }
+
+    .ProseMirror li {
+      margin: 1em 0;
+      margin-left: 1em;
+    }
+  
+    .ProseMirror blockquote {
+      font-size: 2px;
+      padding-left: 1em;
+      border-left: 1px solid #eee;
+    }
+
+    .ProseMirror .math-block {
+      font-size: 2px;
+    }
+
+    .ProseMirror-selectednode {
+      outline: none;
+    }
+  }
+}
+
+

--- a/app/assets/stylesheets/editor/sidebar.scss
+++ b/app/assets/stylesheets/editor/sidebar.scss
@@ -126,6 +126,34 @@
       text-decoration-line: none;
     }
   }
+
+  #sidebarOutline {
+    margin-top: 1em;
+    color: blue;
+    h2 {
+      font-size: 8px;
+      line-height: 8px;
+      padding-bottom: 2em;
+      letter-spacing: -0.1em;
+    }
+
+    h3 {
+      font-size: 8px;
+      line-height: 9px;
+      padding-bottom: 2em;
+      padding-left: 2em;
+      letter-spacing: -0.1em;
+    }
+
+    h4 {
+      font-size: 8px;
+      line-height: 8px;
+      padding-bottom: 2em;
+      padding-left: 4em;
+      letter-spacing: -0.1em;
+    }
+
+  }
 }
 
 

--- a/app/javascript/components/Editor.js
+++ b/app/javascript/components/Editor.js
@@ -3,7 +3,7 @@ import { EditorState } from 'prosemirror-state'
 import { EditorView } from 'prosemirror-view'
 import { commentPluginKey } from './editor-config/comments'
 import { citationPluginKey } from './editor-config/citations'
-// import applyDevTools from 'prosemirror-dev-tools'
+import applyDevTools from 'prosemirror-dev-tools'
 
 export class Editor extends React.Component {
   constructor(props) {
@@ -55,7 +55,7 @@ export class Editor extends React.Component {
       },
     })
 
-    // applyDevTools(this.view)
+    applyDevTools(this.view)
   }
 
   componentDidMount() {

--- a/app/javascript/components/HeadingView.js
+++ b/app/javascript/components/HeadingView.js
@@ -1,0 +1,6 @@
+import React from 'react'
+
+export function HeadingView() {
+  console.log('i am in HeadingView')
+  return <div>hello</div>
+}

--- a/app/javascript/components/Minimap.js
+++ b/app/javascript/components/Minimap.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function Minimap() {
+  return <div>hello i am minimap</div>
+}

--- a/app/javascript/components/Outline.js
+++ b/app/javascript/components/Outline.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import sanitizeHtml from 'sanitize-html'
+
+export function Outline({ headings, title }) {
+  const sanitizedTitle = (html) => {
+    let sanitized =
+      html !== null
+        ? sanitizeHtml(html, {
+            allowedTags: ['b', 'sup', 'sub', 'em', 'code'],
+            allowedAttributes: {},
+          })
+        : 'Untitled'
+    return { __html: sanitized }
+  }
+
+  const outlineItem = (heading) => {
+    let className
+
+    if (heading.level === 2) {
+      className = 'lv-2'
+    } else if (heading.level === 3) {
+      className = 'lv-3'
+    } else {
+      className = 'lv-4'
+    }
+    console.log('heading', heading)
+
+    return (
+      <div
+        className={className}
+        key={heading.id}
+        href={`#${heading.id}`}
+        // dangerouslySetInnerHTML={sanitizedTitle(heading.title)}
+      >
+        <a href={`#${heading.id}`}>{heading.title}</a>
+      </div>
+    )
+  }
+
+  return (
+    <div id="sidebarOutline">
+      <div
+        className="lv-1"
+        dangerouslySetInnerHTML={sanitizedTitle(title)}
+      ></div>
+      {headings.map((heading) => outlineItem(heading))}
+    </div>
+  )
+}

--- a/app/javascript/components/PostEditor.js
+++ b/app/javascript/components/PostEditor.js
@@ -284,7 +284,7 @@ export function PostEditor(props) {
 
         <div className="col-md-2" id="sidebar">
           {post.data.attributes.body && (
-            <Sidebar post={post} options={options} />
+            <Sidebar post={post} options={options} titleOptions={title} />
           )}
         </div>
 

--- a/app/javascript/components/Sidebar.js
+++ b/app/javascript/components/Sidebar.js
@@ -119,7 +119,17 @@ export function Sidebar(props) {
         })
       }
     })
-    return <div>outline</div>
+    return (
+      <div id="sidebarOutline">
+        {headings.map((heading) =>
+          heading.level === 2 ? (
+            <h2 key={heading.id}>{heading.title}</h2>
+          ) : (
+            <h3 key={heading.id}>{heading.title}</h3>
+          )
+        )}
+      </div>
+    )
   }
 
   // initial render
@@ -226,7 +236,7 @@ export function Sidebar(props) {
         tabIndex={0}
       />
 
-      {visible ? (
+      {visible && (
         <div className="sidebarEditorContainer" style={editorContainerStyle}>
           <div
             id="sidebarEditor"
@@ -236,9 +246,8 @@ export function Sidebar(props) {
           />
           <div className="sidebarPortal" style={sidebarPortalStyle} />
         </div>
-      ) : (
-        <div>{getHeadings()}</div>
       )}
+      {!visible && <div>{getHeadings()}</div>}
     </div>
   )
 }

--- a/app/javascript/components/Sidebar.js
+++ b/app/javascript/components/Sidebar.js
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { EditorView } from 'prosemirror-view'
 import { EditorState } from 'prosemirror-state'
 import { math } from './editor-config/math'
+import { v4 as uuidv4 } from 'uuid'
 
 function useEventListener(eventName, handler, element = window) {
   // Create a ref that stores handler
@@ -51,7 +52,7 @@ export function Sidebar(props) {
   const vpHeight = window.innerHeight
 
   const viewHost = useRef()
-  const view = useRef(null)
+  // const view = useRef(null)
 
   const [portalTop, setPortalTop] = useState('0px')
   const [editorContainerHeight, setEditorContainerHeight] = useState(0)
@@ -60,6 +61,18 @@ export function Sidebar(props) {
   const [visible, setVisible] = useState(true)
   const [sticky, setSticky] = useState(false)
   const [mastheadHeight, setMastheadHeight] = useState(0)
+
+  const [view] = useState(
+    new EditorView(viewHost.current, {
+      state: EditorState.create({
+        plugins: [math()],
+        ...props.options,
+      }),
+      editable: function (state) {
+        return false
+      },
+    })
+  )
 
   const calculateEditorPosition = useCallback(
     (sticky, vp, ech) => {
@@ -91,18 +104,26 @@ export function Sidebar(props) {
     [mastheadHeight, calculateEditorPosition, sticky, pageHeight]
   )
 
+  const getHeadings = () => {
+    let headings = []
+
+    view.state.doc.forEach((node) => {
+      if (node.type.name === 'heading') {
+        const id = uuidv4()
+        let name = id
+
+        headings.push({
+          title: node.textContent,
+          level: node.attrs.level,
+          id: name,
+        })
+      }
+    })
+    return <div>outline</div>
+  }
+
   // initial render
   useEffect(() => {
-    view.current = new EditorView(viewHost.current, {
-      state: EditorState.create({
-        plugins: [math()],
-        ...props.options,
-      }),
-      editable: function (state) {
-        return false
-      },
-    })
-
     if (viewHost.current) {
       let editorHeight = viewHost.current.clientHeight
       let pHeight = (vpHeight / pageHeight) * editorHeight
@@ -111,8 +132,8 @@ export function Sidebar(props) {
       const mh = document.getElementsByClassName('masthead')[0]
       setMastheadHeight(mh.offsetHeight + mh.offsetTop)
     }
-    return () => view.current.destroy()
-  }, [pageHeight, props, visible, vpHeight])
+    return () => view.destroy()
+  }, [pageHeight, props, view, visible, vpHeight])
 
   // every render
   useEffect(() => {
@@ -205,7 +226,7 @@ export function Sidebar(props) {
         tabIndex={0}
       />
 
-      {visible && (
+      {visible ? (
         <div className="sidebarEditorContainer" style={editorContainerStyle}>
           <div
             id="sidebarEditor"
@@ -215,6 +236,8 @@ export function Sidebar(props) {
           />
           <div className="sidebarPortal" style={sidebarPortalStyle} />
         </div>
+      ) : (
+        <div>{getHeadings()}</div>
       )}
     </div>
   )

--- a/app/javascript/components/Sidebar.js
+++ b/app/javascript/components/Sidebar.js
@@ -225,16 +225,19 @@ export function Sidebar(props) {
 
   return (
     <div id="sidebarContainer" style={container}>
-      <i
-        id="sidebarToggle"
-        style={toggleIconStyle}
-        className={visible ? 'fa fa-caret-down' : 'fa fa-caret-down rotate'}
-        onClick={() => setVisible(!visible)}
-        onKeyDown={() => setVisible(!visible)}
-        aria-checked={visible}
-        role="switch"
-        tabIndex={0}
-      />
+      <div>
+        <i
+          id="sidebarToggle"
+          style={toggleIconStyle}
+          className={'fas fa-layer-group'}
+          onClick={() => setVisible(!visible)}
+          onKeyDown={() => setVisible(!visible)}
+          aria-checked={visible}
+          role="switch"
+          tabIndex={0}
+        />
+        <bold>{visible ? `Minimap` : `Outline`}</bold>
+      </div>
 
       {visible && (
         <div className="sidebarEditorContainer" style={editorContainerStyle}>

--- a/app/javascript/components/Sidebar.js
+++ b/app/javascript/components/Sidebar.js
@@ -58,7 +58,7 @@ export function Sidebar(props) {
   const [editorContainerHeight, setEditorContainerHeight] = useState(0)
   const [sidebarEditorTop, setSidebarEditorTop] = useState(0)
   const [portalHeight, setPortalHeight] = useState(0)
-  const [visible, setVisible] = useState(true)
+  const [visible, setVisible] = useState('none')
   const [sticky, setSticky] = useState(false)
   const [mastheadHeight, setMastheadHeight] = useState(0)
 
@@ -73,6 +73,16 @@ export function Sidebar(props) {
       },
     })
   )
+
+  const switchVisible = () => {
+    if (visible === 'none') {
+      setVisible('minimap')
+    } else if (visible === 'minimap') {
+      setVisible('outline')
+    } else {
+      setVisible('none')
+    }
+  }
 
   const calculateEditorPosition = useCallback(
     (sticky, vp, ech) => {
@@ -230,16 +240,16 @@ export function Sidebar(props) {
           id="sidebarToggle"
           style={toggleIconStyle}
           className={'fas fa-layer-group'}
-          onClick={() => setVisible(!visible)}
-          onKeyDown={() => setVisible(!visible)}
+          onClick={() => switchVisible()}
+          onKeyDown={() => switchVisible()}
           aria-checked={visible}
           role="switch"
           tabIndex={0}
         />
-        <bold>{visible ? `Minimap` : `Outline`}</bold>
+        {/* <bold>{visible ? `Minimap` : `Outline`}</bold> */}
       </div>
 
-      {visible && (
+      {visible === 'minimap' && (
         <div className="sidebarEditorContainer" style={editorContainerStyle}>
           <div
             id="sidebarEditor"
@@ -250,7 +260,7 @@ export function Sidebar(props) {
           <div className="sidebarPortal" style={sidebarPortalStyle} />
         </div>
       )}
-      {!visible && <div>{getHeadings()}</div>}
+      {visible === 'outline' && <div>{getHeadings()}</div>}
     </div>
   )
 }

--- a/app/javascript/components/editor-config/heading-id.js
+++ b/app/javascript/components/editor-config/heading-id.js
@@ -1,0 +1,15 @@
+import { Plugin } from 'prosemirror-state'
+import { HeadingView } from '../HeadingView'
+
+export function headingId(options) {
+  return new Plugin({
+    props: {
+      nodeViews: {
+        heading: (node, view, getPos) => {
+          console.log('i am in here')
+          return new HeadingView(node, view, getPos)
+        },
+      },
+    },
+  })
+}

--- a/app/javascript/components/editor-config/marks.js
+++ b/app/javascript/components/editor-config/marks.js
@@ -84,25 +84,21 @@ const superscript = {
 }
 
 const strikethrough = {
-  parseDOM: [
-    { tag: 'strike' },
-    { style: 'text-decoration=line-through' },
-    { style: 'text-decoration-line=line-through' },
-  ],
+  parseDOM: [{ tag: 'span.strikethrough' }],
   toDOM: () => [
     'span',
     {
-      style: 'text-decoration-line:line-through',
+      class: 'strikethrough',
     },
   ],
 }
 
 const underline = {
-  parseDOM: [{ tag: 'u' }, { style: 'text-decoration=underline' }],
+  parseDOM: [{ tag: 'span.underline' }],
   toDOM: () => [
     'span',
     {
-      style: 'text-decoration:underline',
+      class: 'underline',
     },
   ],
 }

--- a/app/javascript/components/editor-config/nodes.js
+++ b/app/javascript/components/editor-config/nodes.js
@@ -53,11 +53,13 @@ const defaultNodes = {
     group: 'block',
     defining: true,
     parseDOM: [
+      // { tag: 'h2.magic', attrs: { level: 2 } },
       { tag: 'h2', attrs: { level: 2 } },
       { tag: 'h3', attrs: { level: 3 } },
       { tag: 'h4', attrs: { level: 4 } },
     ],
     toDOM(node) {
+      // return ['h' + node.attrs.level, { id: 'magic' }]
       return ['h' + node.attrs.level, 0]
     },
   },

--- a/app/javascript/components/editor-config/plugins.js
+++ b/app/javascript/components/editor-config/plugins.js
@@ -6,6 +6,7 @@ import { commentPlugin, commentUI } from './comments'
 import { selectPlugin } from './select'
 import { citationPlugin, citationUI } from './citations'
 import { math } from './math'
+import { headingId } from './heading-id'
 import { placeholder } from './placeholder'
 
 // import 'prosemirror-tables/style/tables.css'
@@ -35,6 +36,7 @@ export const bodyPlugins = (getView) => [
     getView().dispatch(transaction)
   }),
   math(),
+  headingId(),
 ]
 
 export const titlePlugins = (getView) => [

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,8 @@ class User < ApplicationRecord
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :confirmable, :lockable, :timeoutable
+         #  :confirmable, :lockable, :timeoutable
+         :lockable, :timeoutable
 
   before_create :downcase_email
   before_create :set_username


### PR DESCRIPTION
This PR
- adds outline component to sidebar using post headings
- matches minimap and post editor styles and ratios
- polishes minimap editor styles

Design: https://www.figma.com/file/gt3p3JDh5W5i5N2wXxE7I5/Design-System?node-id=76%3A86

- [x] refactor .Prosemirror styles in defaults.scss
- [x] refactor sidebar.scss
- [x] polish all #sidebarEditor styles
- [x] update sidebar icon and add sidebar mode labels
- [x] add outline sidebar component
- [x] update sidebarToggle from two modes to three (none, minimap, outline)
- [x] create outline component
- [ ] write plugin to add `id` to heading nodes using the title
- [ ] truncate heading text
- [ ] move minimap code out to minimap component
- [ ] add id to each heading in a post
- [ ] clicking heading in sidebar scrolls user to heading in post editor
- [ ] clicking heading in sidebar updates url with id (user should be able to copy url from browser and share and recipient will land at the desired heading)
- [ ] default to none (sidebar icon only)
- [ ] polish ui (only show sidebar label on hover, dissolve sidebar when typing)
