### PR TITLE
Minimap visual improvements

### DIFF
--- a/app/assets/stylesheets/editor/defaults.scss
+++ b/app/assets/stylesheets/editor/defaults.scss
@@ -46,6 +46,7 @@
 .ProseMirror pre {
   margin-left: 1em;
   border-radius: 0px;
+  margin-bottom: 1em;
 }
 
 .ProseMirror:focus {
@@ -75,6 +76,7 @@
   border-left: 3px solid #eee;
   margin-left: 1em;
   margin-right: 0;
+  margin-bottom: 1em;
 }
 
 .ProseMirror th,

--- a/app/assets/stylesheets/editor/defaults.scss
+++ b/app/assets/stylesheets/editor/defaults.scss
@@ -90,6 +90,14 @@
   line-height: 0;
 }
 
+.ProseMirror span.underline {
+  text-decoration: underline;
+}
+
+.ProseMirror span.strikethrough {
+  text-decoration-line: line-through;
+}
+
 .selection-marker {
   font-family: inherit;
   font-size: inherit;

--- a/app/assets/stylesheets/editor/defaults.scss
+++ b/app/assets/stylesheets/editor/defaults.scss
@@ -4,7 +4,6 @@
     min-width: 640px;
     margin: 0;
     padding: 0;
-
   }
 }
 
@@ -26,6 +25,27 @@
 .ProseMirror {
   font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   background: #fff;
+}
+
+.ProseMirror h2, h3, h4 {
+  padding-bottom: 1em;
+}
+
+.ProseMirror > p {
+  padding-bottom: 1em;
+}
+
+.ProseMirror p.empty-node {
+  padding-bottom: 0;
+}
+
+.ProseMirror img {
+  cursor: default;
+}
+
+.ProseMirror pre {
+  margin-left: 1em;
+  border-radius: 0px;
 }
 
 .ProseMirror:focus {
@@ -57,10 +77,6 @@
   margin-right: 0;
 }
 
-.ProseMirror img {
-  cursor: default;
-}
-
 .ProseMirror th,
 .ProseMirror td {
   border: 1px solid #eee;
@@ -72,31 +88,11 @@
   line-height: 0;
 }
 
-.post-editor .ProseMirror > p {
-  padding-bottom: 1em;
+.selection-marker {
+  font-family: inherit;
+  font-size: inherit;
 }
 
-.post-editor > p {
-  padding-bottom: 1em;
-}
-
-.post-editor .ProseMirror p.empty-node {
-  padding-bottom: 0;
-}
-
-.post-editor .ProseMirror h2, h3, h4 {
-  padding-bottom: 1em;
-}
-
-.post-editor h2, h3, h4 {
-  padding-bottom: 1em;
-}
-
-.post-editor .ProseMirror blockquote {
-  margin-bottom: 1em
-}
-
-// prosemirror-view/style/prosemirror
 // https://github.com/ProseMirror/prosemirror-view/blob/master/style/prosemirror.css
 
 .ProseMirror {
@@ -114,8 +110,6 @@
 
 .ProseMirror pre {
   white-space: pre-wrap;
-  margin-left: 1em;
-  border-radius: 0px;
 }
 
 .ProseMirror li {
@@ -131,10 +125,6 @@
 }
 
 /* Make sure li selections wrap around markers */
-.selection-marker {
-  font-family: inherit;
-  font-size: inherit;
-}
 
 li.ProseMirror-selectednode {
   outline: none;

--- a/app/assets/stylesheets/editor/math.scss
+++ b/app/assets/stylesheets/editor/math.scss
@@ -7,7 +7,7 @@
   content: "( " counter(math-block) " )";
   padding-left: 100px;
   position: absolute;
-  right: 1rem;
+  right: 1em;
 }
 
 .math-block .katex-render {

--- a/app/assets/stylesheets/editor/sidebar.scss
+++ b/app/assets/stylesheets/editor/sidebar.scss
@@ -106,6 +106,14 @@
     .ProseMirror .math-block {
       font-size: 2px;
     }
+
+    .ProseMirror span.underline {
+      text-decoration: none;
+    }
+
+    .ProseMirror span.strikethrough {
+      text-decoration-line: none;
+    }
     
     .ProseMirror-selectednode {
       outline: none;

--- a/app/assets/stylesheets/editor/sidebar.scss
+++ b/app/assets/stylesheets/editor/sidebar.scss
@@ -52,17 +52,28 @@
       padding-top: 2px;
     }
 
-    .ProseMirror h2, h3, h4 {
+    .ProseMirror h2 {
       font-size: 4px;
       line-height: 3px;
       letter-spacing: -0.1em;
-      padding-bottom: 1em;
+    }
+
+    .ProseMirror h3 {
+      font-size: 3px;
+      line-height: 3px;
+      letter-spacing: -0.1em;
+    }
+
+    .ProseMirror h4 {
+      font-size: 2px;
+      line-height: 3px;
+      letter-spacing: -0.1em;
     }
 
     .ProseMirror p, strong, li, a {
       font-size: 2px;
       line-height: 3px;
-      letter-spacing: .05 em;
+      letter-spacing: -0.1 em;
     }
 
     .ProseMirror a {
@@ -114,7 +125,7 @@
     .ProseMirror span.strikethrough {
       text-decoration-line: none;
     }
-    
+
     .ProseMirror-selectednode {
       outline: none;
     }

--- a/app/assets/stylesheets/editor/sidebar.scss
+++ b/app/assets/stylesheets/editor/sidebar.scss
@@ -1,5 +1,27 @@
+
+@include media-breakpoint-down(xl) {
+  #sidebarContainer {
+    display: block;
+  }
+}
+
+@include media-breakpoint-down(lg) {
+  #sidebarContainer {
+    display: block;
+  }
+}
+
 @include media-breakpoint-down(md) {
+  #sidebarContainer {
+    display: none;
+  }
   #sidebar {
+    display: none;
+  }
+}
+
+@include media-breakpoint-down(sm) {
+  #sidebarContainer {
     display: none;
   }
 }
@@ -9,10 +31,6 @@
     display: block;
   }
   display: none;
-
-  a {
-    pointer-events: none;
-  }
 
   #sidebarToggle {
     color: $shaleLight;
@@ -25,84 +43,73 @@
     }
   }
 
-  .ProseMirror {
-    padding-left: 1px;
-    counter-reset: math-block;
-    user-select: none;
-    h1 {
-      font-size: 3px;
-      line-height: 4px;
+  #sidebarEditor {
+    .ProseMirror {
+      padding-left: 1px;
+      padding-right: 1px;
+      counter-reset: math-block;
+      user-select: none;
+      padding-top: 2px;
     }
-    h2, h3, h4 {
-      font-size: 3px;
-      line-height: 4px;
+
+    .ProseMirror h2, h3, h4 {
+      font-size: 4px;
+      line-height: 3px;
       letter-spacing: -0.1em;
+      padding-bottom: 1em;
     }
-    p, strong, li, a {
+
+    .ProseMirror p, strong, li, a {
       font-size: 2px;
       line-height: 3px;
+      letter-spacing: .05 em;
     }
-    img {
+
+    .ProseMirror a {
+      pointer-events: none;
+    }
+
+    .ProseMirror img {
       max-height: 30px;
       text-align: center;
       margin: auto;
     }
-    pre {
-      padding-left: 1px;
-      margin: 0;
-      border-radius: 1px;
-      line-height: 0;
-    }
-    code {
+
+    .ProseMirror pre {
       font-size: 2px;
-      line-height: 0;
+      padding: .5em 1em;
     }
-    li {
-      margin: 2px 0px;
+
+    .ProseMirror ul {
+      font-size: 2px;
+      padding-left: 4em;
+      margin-bottom: 1em;
     }
-    ol {
-      padding-left: 4px;
-      margin-bottom: 4px;
+    
+    .ProseMirror ol {
+      font-size: 2px;
+      padding-left: 2em;
+      margin-bottom: 1em;
     }
-    ul {
-      padding-left: 4px;
-      margin-bottom: 4px;
+    
+    .ProseMirror li {
+      margin: 1em 0;
+      margin-left: 1em;
     }
-    blockquote {
-      padding-left: .2em;
+
+    .ProseMirror blockquote {
+      font-size: 2px;
+      padding-left: 1em;
       border-left: 1px solid #eee;
     }
-    .math-block {
+
+    .ProseMirror .math-block {
       font-size: 2px;
     }
-    .math-block .katex-render::after {
-      counter-increment: math-block;
-      content: counter(math-block)
+    
+    .ProseMirror-selectednode {
+      outline: none;
     }
-  }
-  
-  .ProseMirror-selectednode {
-    outline: none;
   }
 }
 
-@include media-breakpoint-down(xl) {
-  #sidebarContainer {
-    display: block;
-  }
-}
-@include media-breakpoint-down(lg) {
-  #sidebarContainer {
-    display: block;
-  }
-}
-@include media-breakpoint-down(md) {
-  #sidebarContainer {
-    display: none;
-  }
-}
-@include media-breakpoint-down(sm) {
-  #sidebarContainer {
-    display: none;
-  }
-}

--- a/app/javascript/components/editor-config/marks.js
+++ b/app/javascript/components/editor-config/marks.js
@@ -84,25 +84,21 @@ const superscript = {
 }
 
 const strikethrough = {
-  parseDOM: [
-    { tag: 'strike' },
-    { style: 'text-decoration=line-through' },
-    { style: 'text-decoration-line=line-through' },
-  ],
+  parseDOM: [{ tag: 'span.strikethrough' }],
   toDOM: () => [
     'span',
     {
-      style: 'text-decoration-line:line-through',
+      class: 'strikethrough',
     },
   ],
 }
 
 const underline = {
-  parseDOM: [{ tag: 'u' }, { style: 'text-decoration=underline' }],
+  parseDOM: [{ tag: 'span.underline' }],
   toDOM: () => [
     'span',
     {
-      style: 'text-decoration:underline',
+      class: 'underline',
     },
   ],
 }


### PR DESCRIPTION
This PR makes visual improvements to the sidebar minimap.

- [x] updates minimap styles (headings, underline, strikethrough, lists)
- [x] refactors `sidebar.scss` `defaults.scss` 
- [x] removes underline and strikethrough styles from minimap editor 

after:
![image](https://user-images.githubusercontent.com/1177031/101851049-f1eedf00-3afe-11eb-8c56-9ff41bf38e2a.png)

before: 
![image](https://user-images.githubusercontent.com/1177031/101851118-13e86180-3aff-11eb-8b73-c43d21ea35d0.png)


