### PR TITLE
Fixes serialized comment data

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -69,19 +69,19 @@ class PostSerializer
   end
 
   attribute :title_comments do |object|
-    object.comments.title.map{ |comment|
+    object.comments.includes(:user).title.map{ |comment|
 
       if comment.user
         user = {
           id: comment.user.id,
           avatar: comment.user.avatar_url,
-          name: comment.user.full_name || comment.user.username,
+          username: comment.user.username
         }
       else
         user = {
           id: "",
           avatar: User.default_avatar_url,
-          name: "Anonymous",
+          username: "Anonymous",
         }
       end
 
@@ -102,15 +102,13 @@ class PostSerializer
         user = {
           id: comment.user.id,
           avatar: comment.user.avatar_url,
-          name: comment.user.full_name || comment.user.username,
-          username: comment.user.username
+          username: comment.user.username,
         }
       else
         user = {
           id: "",
           avatar: User.default_avatar_url,
-          name: "Anonymous",
-          username: nil
+          username: "Anonymous",
         }
       end
 


### PR DESCRIPTION
This PR updates how title_comments are serialized, so that username shows in title comments.

after:
![image](https://user-images.githubusercontent.com/1177031/101867017-579e9380-3b1e-11eb-96ff-96f0b93f818e.png)

before:
![image](https://user-images.githubusercontent.com/1177031/101867059-6be29080-3b1e-11eb-90fe-94af120a5e2a.png)
