### PR TITLE
Improves search results page design

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,19 @@
 class SearchController < ApplicationController
   def results
-    @results = Post.search(params[:query], page: params[:page], per_page: 20)
+    @results = Post.search(params[:query], page: params[:page], per_page: 10)
+  end
+
+  def paginated_results
+    @paginated_results = Post.search(params[:query], page: params[:page], per_page: 10)
+    respond_to do |format|
+      format.json {
+        render json: {
+          posts: @paginated_results,
+          page: @paginated_results.current_page,
+          page_count: @paginated_results.total_pages
+        }
+      }
+    end
   end
 
   def bar

--- a/app/javascript/components/PostsContainer.js
+++ b/app/javascript/components/PostsContainer.js
@@ -14,7 +14,7 @@ export default function PostsContainer(props) {
   const [pageCount, setPageCount] = useState()
   const [page, setPage] = useState(1)
   const [showPagination, setShowPagination] = useState(false)
-  const [hasPosts, setHasPosts] = useState(false)
+  const [hasPosts, setHasPosts] = useState(true)
   const [, setError] = useState()
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -27,7 +27,7 @@ export default function PostsContainer(props) {
     }
 
     let url = generateUrl()
-    console.log('url', url)
+
     saRequest
       .get(url)
       .set('accept', 'application/json')

--- a/app/javascript/components/SearchResultsContainer.js
+++ b/app/javascript/components/SearchResultsContainer.js
@@ -1,0 +1,12 @@
+import React, { useState } from 'react'
+import PostsList from './PostsList'
+
+export default function SearchResultsContainer({ results }) {
+  const [hasPosts, setHasPosts] = useState(results.length ? true : false)
+
+  const noPosts = () => {
+    return <p className="muted">No results.</p>
+  }
+
+  return <div>{hasPosts ? <PostsList posts={results} /> : noPosts()}</div>
+}

--- a/app/javascript/components/SearchResultsContainer.js
+++ b/app/javascript/components/SearchResultsContainer.js
@@ -1,12 +1,66 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import PostsList from './PostsList'
+import ReactPaginate from 'react-paginate'
+import { saRequest } from '../utils/saRequest'
 
-export default function SearchResultsContainer({ results }) {
-  const [hasPosts, setHasPosts] = useState(results.length ? true : false)
+export default function SearchResultsContainer({ query }) {
+  const [hasPosts, setHasPosts] = useState(true)
+  const [showPagination, setShowPagination] = useState(false)
+  const [pageCount, setPageCount] = useState()
+  const [page, setPage] = useState(1)
+  const [data, setData] = useState([])
+  const [, setError] = useState()
 
-  const noPosts = () => {
-    return <p className="muted">No results.</p>
+  const getSearchResults = useCallback(() => {
+    const generateUrl = () => {
+      return '/search/paginated_results/' + page + '?query=' + query
+    }
+
+    let url = generateUrl()
+
+    saRequest
+      .get(url)
+      .set('accept', 'application/json')
+      .then((res) => {
+        console.log('res', res)
+        setData(res.body.posts)
+        setPageCount(res.body.page_count)
+        setShowPagination(res.body.page_count > 1 ? true : false)
+        setHasPosts(res.body.posts.length !== 0 ? true : false)
+      })
+      .catch((err) => {
+        console.log('err.message', err.message)
+        setError(err.message)
+      })
+  }, [page, query])
+
+  useEffect(() => {
+    getSearchResults()
+  }, [getSearchResults, page])
+
+  const handlePageClick = (e) => {
+    setPage(e.selected + 1)
   }
 
-  return <div>{hasPosts ? <PostsList posts={results} /> : noPosts()}</div>
+  return (
+    <div>
+      {hasPosts && <PostsList posts={data} />}
+      {showPagination && (
+        <ReactPaginate
+          previousLabel={'←'}
+          nextLabel={'→'}
+          breakLabel={'...'}
+          breakClassName={'break-me'}
+          pageCount={pageCount}
+          marginPagesDisplayed={2}
+          pageRangeDisplayed={5}
+          onPageChange={(e) => handlePageClick(e)}
+          containerClassName={'pagination'}
+          subContainerClassName={'pages pagination'}
+          activeClassName={'active'}
+          forcePage={page - 1}
+        />
+      )}
+    </div>
+  )
 }

--- a/app/views/search/results.html.slim
+++ b/app/views/search/results.html.slim
@@ -1,9 +1,9 @@
 - query = params[:query]
 
 .container
-  h1 Search Results
+  h1.mb-4 Search Results
 
-  h2
+  h2.mb-4
     - if @results.count > 0
       = @results.total_count
       | &nbsp;results found for&nbsp;
@@ -13,13 +13,15 @@
 
 
   .row
-    .col-md-6
-      - @results.each do |result|
-        = link_to result do
-          .search-result
-            h4
-              = sanitize_title(result.title)
-            p
-              = result.created_at.strftime("%D")
+    .col-md-12
+      = react_component "SearchResultsContainer",
+        results: @results
+  /     - @results.each do |result|
+  /       = link_to result do
+  /         .search-result
+  /           h4
+  /             = sanitize_title(result.title)
+  /           p
+  /             = result.created_at.strftime("%D")
 
-  = will_paginate(@results)
+  / = will_paginate(@results)

--- a/app/views/search/results.html.slim
+++ b/app/views/search/results.html.slim
@@ -1,27 +1,20 @@
 - query = params[:query]
 
 .container
-  h1.mb-4 Search Results
-
-  h2.mb-4
-    - if @results.count > 0
+  h2.mb-4.mt-5
+    - if @results.total_count > 0 
       = @results.total_count
-      | &nbsp;results found for&nbsp;
-      strong = query
+      | &nbsp;results for&nbsp;
+      em = query
+    - elsif @results.total_count == 1
+      | 1 result for 
+      em = query
     - else
-      | 0 results found
+      | No results for 
+      em = query
 
-
+  hr
   .row
     .col-md-12
       = react_component "SearchResultsContainer",
-        results: @results
-  /     - @results.each do |result|
-  /       = link_to result do
-  /         .search-result
-  /           h4
-  /             = sanitize_title(result.title)
-  /           p
-  /             = result.created_at.strftime("%D")
-
-  / = will_paginate(@results)
+        query: query

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,11 @@ Rails.application.routes.draw do
   post '/remove_citation', to: 'citations#delete', as: :remove_citation
 
   namespace :search do
+    get :paginated_results
+  end
+  get 'search/paginated_results/:page', to: 'search#paginated_results', defaults: {format: 'json'} 
+
+  namespace :search do
     get :results
     get :bar
   end


### PR DESCRIPTION
This PR improves search results page ux/ui design.

- [x] reduce per page results from 20 to 10
- [x] design for <10 results
- [x] design for 0 results
- [x] design for >= 10 results, pagination
- [x] add route for paginated results 
- [x] add SearchResultsContainer
- [x] update PostsContainer to default `hasPosts` to `true` (component is optimistic that posts are present)

~fix bug where total number of results not matching number of posts shown~*

*Once this PR is approved and merged, check in production for the results pages returning < 10 results because some records no longer exist in the database. To fix, run `Post.reindex` in console to reindex and resolve. https://github.com/ankane/searchkick#to-reindex-or-not-to-reindex

after: 
![Kapture 2020-12-13 at 15 12 20](https://user-images.githubusercontent.com/1177031/102030151-9d916c80-3d55-11eb-8c9a-8fe65524fb10.gif)

before:
![before](https://user-images.githubusercontent.com/1177031/101999237-140f6b00-3c7f-11eb-9c7f-7748c028907e.gif)
