### PR TITLE
Adds twitter card for collections

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -20,6 +20,7 @@ class TagsController < ApplicationController
       .order(created_at: :desc)
       .paginate(page: params[:citations_page], per_page: 10)
 
+    @username = User.find_by_id(@tag.user_id).username
   end
 
   def new

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,7 +1,19 @@
 module PostsHelper
   def meta_description(post)
+    if post.abstract
+      "#{meta_tag_sanitize_and_truncate(post.abstract)}"
+    end
+  end
+  
+  def meta_authors(post)
     if post.authors
       "#{post.authors.truncate(120)}"
+    end
+  end
+
+  def meta_title(post)
+    if post.title.present?
+      "#{meta_tag_sanitize_and_truncate(post.title)}"
     end
   end
 

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,10 +1,6 @@
 module TagsHelper
-  def tag_description(tag)
-    if tag.posts.present?
-      tag.posts.count > 1 ? "A collection of #{tag.posts.count} posts" : "A collection of one post"
-    else
-      "An empty collection"
-    end
+  def tag_description(username)
+    "A collection created by @#{@username}"
   end
 
   def tag_text(tag)

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,2 +1,15 @@
 module TagsHelper
+  def tag_description(tag)
+    if tag.posts.present?
+      tag.posts.count > 1 ? "A collection of #{tag.posts.count} posts" : "A collection of one post"
+    else
+      "An empty collection"
+    end
+  end
+
+  def tag_text(tag)
+    if tag.text
+      "#{meta_tag_sanitize_and_truncate(@tag.text)}"
+    end
+  end
 end

--- a/app/views/layouts/_head.html.slim
+++ b/app/views/layouts/_head.html.slim
@@ -1,6 +1,8 @@
 ruby:
   meta_description = content_for?(:meta_description) ? yield(:meta_description) : "Do The Science"
   meta_twitter_creator = content_for?(:meta_twitter_creator) ? yield(:meta_twitter_creator) : "@jellypbc"
+  meta_title = content_for?(:title) ? yield(:title) : "Untitled"
+  meta_twitter_description = content_for?(:meta_twitter_description) ? yield(:meta_twitter_description) : "Anonymous"
 
   if content_for?(:meta_project_image_url)
     meta_image_url = yield(:meta_project_image_url)
@@ -35,8 +37,8 @@ head
   meta name="twitter:domain" content="jellypbc.com"
   meta name='twitter:site' content='@jellypbc'
   meta name='twitter:widgets:csp' content='on'
-  meta name="twitter:title" content=yield(:title)
-  meta name="twitter:description" content=meta_tag_sanitize_and_truncate(meta_description)
+  meta name="twitter:title" content=meta_tag_sanitize_and_truncate(meta_title)
+  meta name="twitter:description" content=meta_tag_sanitize_and_truncate(meta_twitter_description)
   meta name="twitter:image" content=meta_image_url
   meta name="twitter:card" content="summary"
 

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -1,5 +1,6 @@
-- content_for(:title) { "#{meta_tag_sanitize_and_truncate(@post.title)}" } if @post.title
 - content_for(:meta_description) { meta_description(@post) }
+- content_for(:title) { meta_title(@post) }
+- content_for(:meta_twitter_description) { meta_authors(@post) }
 - guest_user = { data: { attributes: {name: "Anonymous", avatar_url: User.default_avatar_url } } }
 
 #post.container data-post-id=@post.id

--- a/app/views/tags/show.html.slim
+++ b/app/views/tags/show.html.slim
@@ -1,5 +1,5 @@
 - content_for(:title) { tag_text(@tag) }
-- content_for(:meta_twitter_description) { tag_description(@tag) }
+- content_for(:meta_twitter_description) { tag_description(@username) }
 
 .users
   .container.my-5

--- a/app/views/tags/show.html.slim
+++ b/app/views/tags/show.html.slim
@@ -1,3 +1,6 @@
+- content_for(:title) { tag_text(@tag) }
+- content_for(:meta_twitter_description) { tag_description(@tag) }
+
 .users
   .container.my-5
     header.row.my-5


### PR DESCRIPTION
This PR adds `meta_title` and `meta_twitter_description` to generate twitter cards for collections.

Updates twitter cards for posts, so title defaults to `Untitled` and author to `Anonymous` when those fields are not present.

Twitter cards cannot be tested locally, so this will be tested live.

Addresses #353 

Collection twitter card design
![image](https://user-images.githubusercontent.com/1177031/102859621-51d36880-43d0-11eb-9284-d194551c9c5e.png)

Post twitter card design
![image](https://user-images.githubusercontent.com/1177031/102750889-cb088800-430a-11eb-9b1d-b91839e9127e.png)
