### PR TITLE
Fixes 500 error on /edit pages

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -146,7 +146,6 @@ class PostsController < ApplicationController
         .map(&:tags)
         .flatten
         .uniq
-        .select{|tag| tag.post_id != @post.id }
         .map{ |tag| {
           id: tag.id.to_s,
           text: tag.text,


### PR DESCRIPTION
Fixes #378. 

`tag` does not have a `post_id` attribute.