### PR TITLE
Match placeholder post styles to PostPage styles

### DIFF
--- a/app/views/posts/_placeholder_post.html.slim
+++ b/app/views/posts/_placeholder_post.html.slim
@@ -11,9 +11,9 @@
                 = link_to 'View PDF', post.uploads.first.file_url, target: '_blank'
         .title
           - if post.title.present? && post.title != "<p></p>"
-            h1 = post.title.html_safe
+            h1.ProseMirror = post.title.html_safe
           - else 
-            h1.title-placeholder 
+            h1.title-placeholder.ProseMirror
               = "Untitled"
 
         .authors
@@ -23,11 +23,12 @@
     #sidebarContainer
   .col-md-8.center-column
     .post-editor
-      - if post.body.present? && post.body != "<p></p>"
-        = post.body.html_safe
-      - else 
-        .body-placeholder
-          = "A blank post."
+      .ProseMirror
+        - if post.body.present? && post.body != "<p></p>"
+          = post.body.html_safe
+        - else 
+          .body-placeholder
+            = "A blank post."
 
 
     - if post.citations.any?


### PR DESCRIPTION
With this PR, there is no visible difference between the placeholder post and the PostPage component.

The visible difference between placeholder post and PostPage component caused a jumpy experience for the user. This PR resolves that.

After:
(L = placeholder, R = PostPage component)
<img width="1440" alt="Reflections on 2020 as an independent researcher | Jelly 2021-01-18 19-17-38" src="https://user-images.githubusercontent.com/1177031/104991304-86801300-59c2-11eb-917b-e723bb9b3169.png">

Before:
(L = placeholder, R = PostPage component)
<img width="1437" alt="Reflections on 2020 as an independent researcher | Jelly 2021-01-18 19-18-50" src="https://user-images.githubusercontent.com/1177031/104991312-8b44c700-59c2-11eb-8b9d-f98f5c2d0730.png">
