### PR TITLE
Upgrades to jquery 3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "es6-promise": "^4.2.8",
     "html-react-parser": "^0.13.0",
     "immer": "^7.0.8",
-    "jquery": "^3.4.1",
+    "jquery": "3.5.1",
     "katex": "^0.12.0",
     "lodash": "4.17.19",
     "popper.js": "^1.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6700,10 +6700,10 @@ jest-worker@^26.3.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@^3.4.1:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+jquery@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-base64@^2.1.8:
   version "2.5.2"


### PR DESCRIPTION
Fixes https://github.com/jellypbc/poster/issues/392

after:
![Kapture 2021-02-04 at 18 00 10](https://user-images.githubusercontent.com/1177031/106988207-42f00d80-6713-11eb-99a6-d741bb858ce8.gif)

before: 
![Kapture 2021-02-04 at 18 07 33](https://user-images.githubusercontent.com/1177031/106988447-e6412280-6713-11eb-94be-cb8bbb3a4c3b.gif)

reference: https://ursualexandr-21492.medium.com/uncaught-typeerror-cannot-convert-object-to-primitive-value-ea83623ca517

