### PR TITLE
Fix reply to comment bug

### DIFF
--- a/app/javascript/components/editor-config/comments.js
+++ b/app/javascript/components/editor-config/comments.js
@@ -319,7 +319,7 @@ function ThreadedComment(props) {
     setIsShowingReply(true)
   }
 
-  const handleReplySubmit = ({ text = 'Comment...' }) => {
+  const handleReplySubmit = ({ text = 'Comment...', highlightedText = '' }) => {
     const replyTo = commentPluginKey.getState(state).findComment(comment.id)
     const user = buildUser()
 


### PR DESCRIPTION
Fixes https://github.com/jellypbc/poster/issues/423

This PR fixes a bug introduced by https://github.com/jellypbc/poster/pull/417 where users are unable to reply to comments. This is a quick fix. For a full solution, we need to pass the accurate `highlightedText` from the CommentForm component into `handleReplySubmit` or generate the highlightedText string in `comments.js`.

I opted not to do a full fix because comments is not our priority right now. My estimate for a full fix is 1 hour to 1/2 day.

After:
![Kapture 2021-03-11 at 08 30 39](https://user-images.githubusercontent.com/1177031/110836501-38f68880-8244-11eb-803a-b3709bb37155.gif)

Before:
![Kapture 2021-03-11 at 08 31 25](https://user-images.githubusercontent.com/1177031/110836491-35630180-8244-11eb-9cd3-c709c8f8cc80.gif)

