### PR TITLE
Fixes footer overlapping button

### DIFF
--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -1,4 +1,4 @@
-footer.footer.mt-auto
+footer.footer
 	= link_to root_path do
 		.back_to_home
   		= image_tag 'jelly.png'


### PR DESCRIPTION
Bug: Footer was sitting on top of Log In/Registration button when user is zoomed in. Bug also happens on my tiny iPhone SE screen.

After:
![Kapture 2021-07-07 at 18 38 55](https://user-images.githubusercontent.com/1177031/124863360-a5fbff80-df52-11eb-8d80-a6ae851a330f.gif)


Before:
![image](https://user-images.githubusercontent.com/1177031/124863052-23734000-df52-11eb-9b72-380b1e9d78f0.png)

